### PR TITLE
Rework github webhook to handle requests asynchronously

### DIFF
--- a/functions/index.js
+++ b/functions/index.js
@@ -1,45 +1,59 @@
 const admin = require('firebase-admin')
 const functions = require('firebase-functions')
-admin.initializeApp(functions.config().firebase)
-const db = admin.firestore()
-
 const Github = require('./lib/github')
 const Cla = require('./lib/cla')
+
+admin.initializeApp(functions.config().firebase)
+const db = admin.firestore()
 
 const clalib = new Cla(db)
 const github = new Github(
   functions.config().github.app_id,
   functions.config().github.key,
   functions.config().github.secret,
-  clalib)
-
-exports.githubWebook = functions.https.onRequest(github.handler)
-
-// Add functions in response to DB changes
-// https://firebase.google.com/docs/firestore/extend-with-functions
-
-// exports.modifyUser = functions.firestore
-//   .document('clas/{claID}')
-//   .onWrite((change) => {
-//     // Get an object with the current document value.
-//     // If the document does not exist, it has been deleted.
-//     const document = change.after.exists ? change.after.data() : null
-//
-//     // Get an object with the previous document value (for update or delete)
-//     // const oldDocument = change.before.toJson()
-//
-//     // Check to see if there are any outstanding PRs for newly added users
-//     if (document) {
-//       const whitelist = document.data().whitelist
-//       console.log('rechecking', whitelist)
-//       // TODO: re-enable once recheckPrsForEmails is fixed
-//       // github.recheckPrsForEmails(whitelist)
-//     }
-//   })
+  db)
 
 /**
- * When a new addendum is created, update the list of active contributors in the parent agreement.
+ * When a new addendum is created, update the whitelists collection with the
+ * list of allowed identities for the parent agreement.
  */
 exports.updateWhitelist = functions.firestore
   .document('/addendums/{id}')
   .onCreate(clalib.updateWhitelist)
+
+/**
+ * Handles GitHub pull requests and other events. For pull requests, the
+ * implementation is expected to create a new request document in the DB, which
+ * will be picked up by the below function.
+ */
+exports.githubWebook = functions.https.onRequest(github.handler)
+
+/**
+ * When a new CLA validation request is created, e.g. by the GitHub webhook,
+ * process it. The implementation is expected to update the status of the
+ * contribution (e.g., GitHub PR) in the corresponding server and wait for an
+ * ack. Request documents should be updated in the DB with an indication if the
+ * ack was successful or if any error occurred.
+ */
+exports.handleRequest = functions.firestore
+  .document('/requests/{id}')
+  .onCreate(snapshot => {
+    if (!snapshot.exists) {
+      return Promise.reject(new Error('snapshot does not exist'))
+    }
+    const request = snapshot.data()
+    if (!('type' in request)) {
+      return Promise.reject(new Error('missing type key in request'))
+    }
+    if (request.type === 'github') {
+      return github.processRequest(snapshot)
+    } else {
+      return Promise.reject(new Error(`unknown request type ${request.type}`))
+    }
+  })
+
+// TODO: implement cronjob function to periodically clean up acknowledged and
+//  outdated requests.
+
+// TODO: implement logic to re-process any pending request every time the
+//  whitelists collection is updated.

--- a/functions/lib/github.js
+++ b/functions/lib/github.js
@@ -1,14 +1,8 @@
+const util = require('./util')
+const Cla = require('./cla')
 const App = require('@octokit/app')
 const Octokit = require('@octokit/rest')
 const WebhooksApi = require('@octokit/webhooks')
-
-// const debug = false
-// const reqLogger = {
-//  debug: debug ? () => {} : console.log,
-//  info: debug ? () => {} : console.log,
-//  warn: console.warn,
-//  error: console.error
-// }
 
 module.exports = Github
 
@@ -17,151 +11,198 @@ module.exports = Github
  * @param appId {number}
  * @param privateKey {string}
  * @param secret {string}
- * @param clalib {Cla}
+ * @param db {FirebaseFirestore.Firestore}
  * @constructor
  */
-function Github (appId, privateKey, secret, clalib) {
-  const ghApp = new App({ id: appId, privateKey: privateKey })
+function Github (appId, privateKey, secret, db) {
+  const ghApp = new App({
+    id: appId,
+    // Key is passed aa firebase config string with new lines encoded as "\n".
+    // We need to replace "\n" with actual new line characters.
+    privateKey: privateKey.replace(/\\n/g, '\n')
+  })
   // const jwt = app.getSignedJsonWebToken() // global app token
   const ghWebhooks = new WebhooksApi(secret ? { secret } : {})
-
-  ghWebhooks.on('*', (event) => {
-    console.log('event received', event)
-  })
-
-  ghWebhooks.on('error', (error) => {
-    console.log('error occurred', error)
-  })
 
   ghWebhooks.on(
     [
       'pull_request.opened',
+      'pull_request.reopened',
       'pull_request.synchronize'
-    ], async context => {
+    ], context => {
+      // Store request to the db. We'll process it later.
       // TODO: check repo owner and discard if it's not managed by ONF
+      // TODO: create a request model
       const pr = context.payload.pull_request
-      const owner = pr.base.repo.owner.login
-      const repo = pr.base.repo.name
-      const prNum = pr.number
-      const eventType = context.payload.action
-      const numCommits = pr.commits
-
-      console.log(`Pull Request: ${owner}/${repo}/${prNum}, type ${eventType}, ${numCommits} commits`)
-
-      const installationId = context.payload.installation.id
-      const installationAccessToken = await ghApp.getInstallationAccessToken({ installationId })
-
-      const ghClient = new Octokit({
-        auth: installationAccessToken // jwt,
-        // log: reqLogger //FIXME
-      })
-
-      const status = {
-        owner: owner,
-        repo: repo,
-        context: 'clam',
-        sha: pr.head.sha
-      }
-
-      // TODO if numCommits <= 250, use the commits_url or pull request list
-      //  commits API else, use the repo commits API; can be an error for now
-      if (numCommits > 250) {
-        // Should post a status to the PR
-        status.state = 'failure'
-        status.target_url = 'https://sign.the.cla'
-        status.description = 'Cannot evaluate CLA for this PR. ' +
-          'Number of commits exceeds the 250 commit limit. ' +
-          'Please contact contact support@opennetworking.org'
-        return ghClient.repos.createStatus(status)
-      }
-
-      // We need a CLA in file for the PR author (github ID), as well as for all
-      // the identities associated with all commits of this PR.
-      const identities = getPrIdentities(pr, ghClient)
-
-      return clalib.checkIdentities(identities).then(result => {
-        if (result.allWhitelisted) {
-          console.log('cla is signed for all commits')
-          status.state = 'success'
-          status.description = 'All good! We have a CLA in file for all contributors in this PR.'
-        } else {
-          let msg
-          if (result.missingIdentities.length) {
-            msg = 'We could not find a CLA for the following identities: ' +
-              result.missingIdentities +
-              '. You will need to sign one before we can merge your PR.'
-          } else {
-            msg = 'We were not able to verify the CLA for this PR. ' +
-              'If the problem persists please contact support@opennetworking.org'
-          }
-          status.state = 'failure'
-          status.target_url = 'https://sign.the.cla'
-          status.description = msg
-        }
-        return ghClient.repos.createStatus(status)
-      })
+      return db.collection('requests')
+        .add({
+          contributionId: `github.com/${pr.base.repo.full_name}/pull/${pr.number}`,
+          receivedOn: new Date(),
+          type: 'github',
+          event: 'pull_request.' + context.payload.action,
+          payload: context.payload,
+          app: {
+            installationId: context.payload.installation.id
+          },
+          identities: null,
+          lastRunStatus: null,
+          lastRunOn: null,
+          processedCount: 0
+        })
+        .catch(error => {
+          console.error(error)
+        }).finally()
     })
 
-  async function getPrIdentities (pr, ghClient) {
+  /**
+   * Process a request from the database.
+   * @param requestSnapshot {DocumentSnapshot}
+   * @returns {Promise}
+   */
+  async function processRequest (requestSnapshot) {
+    const req = requestSnapshot.data()
+    console.log(`contributionId=${req.contributionId}, event=${req.event}, receivedOn=${req.receivedOn}`)
+
+    const pr = req.payload.pull_request
+
+    const installationId = req.app.installationId
+    const accessToken = await ghApp.getInstallationAccessToken({ installationId })
+    const octokit = new Octokit({ auth: accessToken })
+
+    // Status to post to GitHub. We need to determine a state and a description.
+    req.lastStatus = {
+      owner: pr.base.repo.owner.login,
+      repo: pr.base.repo.name,
+      context: 'cla-validation',
+      sha: pr.head.sha,
+      target_url: 'https://cla.opennetworking.org',
+      description: null,
+      state: null
+    }
+    req.lastProcessedOn = new Date()
+    req.processedCount = req.processedCount + 1
+
+    // Extract identities (if it's the first we process this request)
+    if (!req.identities) {
+      if (pr.commits > 250) {
+        // TODO if numCommits <= 250, use the commits_url or pull request list
+        //  commits API else, use the repo commits API; can be an error for now
+        req.lastStatus.state = 'error'
+        req.lastStatus.description = 'number of commits exceed the 250 limit'
+      } else {
+        try {
+          req.identities = await getPrIdentities(pr, octokit)
+        } catch (error) {
+          console.error(error)
+          req.lastStatus.state = 'error'
+          req.lastStatus.description = 'internal error'
+        }
+      }
+    }
+
+    // If we managed to extract identities (state is not error), verify that all
+    // identities are whitelisted.
+    if (!req.lastStatus.state) {
+      if (Array.isArray(req.identities) && req.identities.length > 0) {
+        // Check whitelist.
+        const cla = Cla(db)
+        try {
+          const checkResult = await cla.checkIdentities(
+            req.identities.map(util.identityObj))
+          if (checkResult.allWhitelisted) {
+            req.lastStatus.state = 'success'
+            req.lastStatus.description = 'All good! We have a CLA in file for all contributors in this PR.'
+          } else {
+            if (checkResult.missingIdentities.length) {
+              req.lastStatus.state = 'failure'
+              req.lastStatus.description =
+                'We could not find a CLA for the following identities: ' +
+                checkResult.missingIdentities.join(', ') +
+                '. You will need to sign one before we can accept this contribution.'
+            } else {
+              req.lastStatus.state = 'error'
+              req.lastStatus.description = 'whitelist verification failed but missing identities is empty'
+            }
+          }
+        } catch (error) {
+          console.error(error)
+          req.lastStatus.state = 'error'
+          req.lastStatus.description = 'cannot check whitelist'
+        }
+      } else if (Array.isArray(req.identities)) {
+        req.lastStatus.state = 'error'
+        req.lastStatus.description = 'empty identities'
+      } else {
+        req.lastStatus.state = 'error'
+        req.lastStatus.description = 'invalid identities'
+      }
+    }
+
+    // We should have a state to report by now.
+    if (!req.lastStatus.state) {
+      req.lastStatus.state = 'error'
+      req.lastStatus.description = 'internal error'
+    }
+
+    // If any error occurred, improve description shown to user.
+    if (req.lastStatus.state === 'error') {
+      req.lastStatus.description =
+        `We were unable to verify the CLA: ${req.lastStatus.description}. ` +
+        'If the problem persists, please contact support@opennetworking.org.'
+    }
+
+    // Post status to Github.
+    try {
+      const octoResponse = await octokit.repos.createStatus(req.lastStatus)
+      req.lastStatus.octoAck = octoResponse.status === 200
+      req.lastStatus.octoResponse = {
+        status: octoResponse.status,
+        data: octoResponse.data
+      }
+    } catch (e) {
+      req.lastStatus.octoAck = false
+      req.lastStatus.octoError = JSON.parse(JSON.stringify(e))
+    }
+
+    // Finally, update request in the db.
+    return requestSnapshot.ref.update(req)
+      .catch(error => {
+        console.log(error)
+        return Promise.reject(error)
+      })
+  }
+
+  async function getPrIdentities (pr, octokit) {
     // We need a CLA in file for the PR author (github ID), as well as for all
     // the identities associated with all commits of this PR.
-    const identities = [{ type: 'github', value: pr.user.login }]
-    const responses = await ghClient.paginate.iterator(`GET ${pr.commits_url}`)
+    const identities = [`github:${pr.user.login}`]
+    const responses = await octokit.paginate.iterator(`GET ${pr.commits_url}`)
     for await (const response of responses) {
       response.data.map(commit => getCommitIdentities(commit))
         .forEach(x => identities.push(...x))
     }
-    return identities
+    return Array.from(new Set(identities))
   }
 
   function getCommitIdentities (commit) {
-    // FIXME this is a hack for storing PR toJson
-    const match = commit.url.match(/repos\/([^/]+)\/([^/]+)/)
-    const ref = {
-      owner: match[1],
-      repo: match[2],
-      sha: commit.sha
-    }
-    console.log(ref)
-
     const identities = [
-      { type: 'github', value: commit.author.login },
-      { type: 'email', value: commit.commit.author.email }
+      `github:${commit.author.login}`,
+      `email:${commit.commit.author.email}`
     ]
-
     if (commit.committer.login !== 'web-flow') {
       identities.push(...[
-        { type: 'github', value: commit.committer.login },
-        { type: 'email', value: commit.commit.committer.email }
+        `github:${commit.committer.login}`,
+        `email:${commit.commit.committer.email}`
       ])
     }
-
-    return identities
+    return Array.from(new Set(identities))
   }
-
-  // function recheckPrsForEmails (emails) {
-  //   console.log('rechecking:', emails)
-  //   return Promise.all(emails.map(async email => {
-  //     const refs = await claClient.getPrsForEmail(email)
-  //     return refs.map(ref => {
-  //       // FIXME This is a Hack that won't work if there is more than one commit
-  //       return client.repos.createStatus({
-  //         owner: ref.owner,
-  //         repo: ref.repo,
-  //         sha: ref.sha,
-  //         context: 'cla-manager',
-  //         state: 'success',
-  //         description: 'CLA is signed'
-  //       })
-  //     })
-  //   }))
-  // }
 
   return {
     receive: ghWebhooks.receive,
     handler: ghWebhooks.middleware,
+    processRequest: processRequest,
     getPrIdentities: getPrIdentities,
     getCommitIdentities: getCommitIdentities
-    // recheckPrsForEmails
   }
 }

--- a/functions/lib/github.js
+++ b/functions/lib/github.js
@@ -17,7 +17,7 @@ module.exports = Github
 function Github (appId, privateKey, secret, db) {
   const ghApp = new App({
     id: appId,
-    // Key is passed aa firebase config string with new lines encoded as "\n".
+    // Key is passed as a firebase config string with new lines encoded as "\n".
     // We need to replace "\n" with actual new line characters.
     privateKey: privateKey.replace(/\\n/g, '\n')
   })

--- a/functions/lib/github.js
+++ b/functions/lib/github.js
@@ -25,12 +25,12 @@ function Github (appId, privateKey, secret, clalib) {
   // const jwt = app.getSignedJsonWebToken() // global app token
   const ghWebhooks = new WebhooksApi(secret ? { secret } : {})
 
-  ghWebhooks.on('*', ({ id, name, payload }) => {
-    console.log(name, 'event received')
+  ghWebhooks.on('*', (event) => {
+    console.log('event received', event)
   })
 
   ghWebhooks.on('error', (error) => {
-    console.log(`Error occured in "${error.event.name} handler: ${error.stack}"`)
+    console.log('error occurred', error)
   })
 
   ghWebhooks.on(

--- a/functions/lib/util.js
+++ b/functions/lib/util.js
@@ -1,0 +1,34 @@
+/**
+ * Returns a string that uniquely identifies the given identity object.
+ * @param identityObj {{type: string, value: string}}
+ * @returns {string}
+ */
+module.exports.identityKey = function (identityObj) {
+  if (!identityObj || !('type' in identityObj) || !('value' in identityObj)) {
+    throw new Error('Invalid identity object')
+  }
+  const lcValue = identityObj.value.toLowerCase()
+  return `${identityObj.type}:${lcValue}`
+}
+
+/**
+ * Returns an identity object with type and value from the given key.
+ * @param identityKey {string}
+ * @returns {{type: string, value: string}}
+ */
+module.exports.identityObj = function (identityKey) {
+  if (!identityKey) {
+    throw new Error('Identity key is falsy')
+  }
+  if (!(typeof identityKey === 'string' || identityKey instanceof String)) {
+    throw new Error('Invalid identity key is not a string')
+  }
+  const i = identityKey.indexOf(':')
+  if (i < 0) {
+    throw new Error('Invalid identity key')
+  }
+  return {
+    type: identityKey.slice(0, i),
+    value: identityKey.slice(i + 1)
+  }
+}

--- a/functions/package.json
+++ b/functions/package.json
@@ -17,7 +17,7 @@
     "deploy": "npx firebase deploy --only functions",
     "logs": "npx firebase functions:log",
     "pretest": "npm run lint",
-    "test": "npx firebase emulators:exec --only firestore 'test/run.sh'"
+    "test": "npx firebase emulators:exec --only firestore 'jest'"
   },
   "dependencies": {
     "@octokit/app": "^2.2.5",

--- a/functions/test/github.test.js
+++ b/functions/test/github.test.js
@@ -47,7 +47,7 @@ describe('Github lib', () => {
     requestsRef = db.collection('requests')
     fs.readFile(path.join(__dirname, 'fixtures/mock-cert.pem'), (err, cert) => {
       if (err) return done(err)
-      mockCert = cert
+      mockCert = cert.toString()
       return done()
     })
   })

--- a/functions/test/github.test.js
+++ b/functions/test/github.test.js
@@ -1,3 +1,5 @@
+import { addAndGetSnapshot, setupDbAdmin, teardownDb } from './helpers'
+
 const nock = require('nock')
 const fs = require('fs')
 const path = require('path')
@@ -12,31 +14,37 @@ const payload = require('./fixtures/pull_request.opened')
 const hugePayload = require('./fixtures/pull_request.opened.huge')
 const commits = require('./fixtures/commits')
 
-const checkIdentifiesSuccess = async () => {
-  return Promise.resolve({
-    allWhitelisted: true,
-    missingIdentities: []
-  })
+const mockRequest = {
+  app: { installationId: 555 },
+  contributionId: 'github.com/bocon13/cla-test/pull/3',
+  event: 'pull_request.opened',
+  payload: payload,
+  type: 'github',
+  identities: null,
+  lastRunStatus: null,
+  lastRunOn: null,
+  processedCount: 0
 }
 
-const checkIdentifiesFail = async () => {
-  return Promise.resolve({
-    allWhitelisted: false,
-    missingIdentities: []
-  })
-}
+const mockIdentities = ['github:bocon13', 'email:bocon@opennetworking.org']
+
+const statusUri = '/repos/bocon13/cla-test/statuses/2129e453f6d652badfb353c510a3669873a15f7c'
+
+const appId = 123
+
+const projectId = 'github-test-' + new Date()
 
 nock.disableNetConnect()
 
-describe('Github PR Webhook', () => {
-  const appId = 123
+describe('Github lib', () => {
+  let db
   let github
   let mockCert
-  const cla = {
-    checkIdentities: checkIdentifiesSuccess
-  }
+  let requestsRef
 
-  beforeAll((done) => {
+  beforeAll(async (done) => {
+    db = await setupDbAdmin(null, projectId)
+    requestsRef = db.collection('requests')
     fs.readFile(path.join(__dirname, 'fixtures/mock-cert.pem'), (err, cert) => {
       if (err) return done(err)
       mockCert = cert
@@ -44,8 +52,18 @@ describe('Github PR Webhook', () => {
     })
   })
 
+  afterEach(async () => {
+    // FIXME: find a way to clear the database after each test.
+    //  calling this triggers a grpc error
+    // await clearDb(projectId)
+  })
+
+  afterAll(async () => {
+    await teardownDb()
+  })
+
   beforeEach(() => {
-    github = new Github(appId, mockCert, 'secret', cla)
+    github = new Github(appId, mockCert, 'secret', db)
     // Return a token for fake application (id=555)
     nock('https://api.github.com')
       .post('/app/installations/555/access_tokens')
@@ -56,66 +74,138 @@ describe('Github PR Webhook', () => {
       .reply(200, commits)
   })
 
-  test('PR identities can be extracted', async () => {
-    const ghClient = new Octokit({ auth: 'accesstoken' })
-    const identities = await github.getPrIdentities(payload.pull_request, ghClient)
-    expect(identities[0]).toMatchObject({ type: 'github', value: 'bocon13' })
-    expect(identities[1]).toMatchObject({ type: 'github', value: 'bocon13' })
-    expect(identities[2]).toMatchObject({
-      type: 'email',
-      value: 'bocon@opennetworking.org'
-    })
+  test('PR identities should be extracted', async () => {
+    const octokit = new Octokit({ auth: 'accesstoken' })
+    const identities = await github.getPrIdentities(payload.pull_request, octokit)
+    expect(identities.length).toBe(2)
+    expect(identities[0]).toBe(mockIdentities[0])
+    expect(identities[1]).toBe(mockIdentities[1])
     expect(true)
   })
 
-  test('Commit identities can be extracted', async () => {
+  test('Commit identities should be extracted', async () => {
     const identities = github.getCommitIdentities(commits[0])
-    expect(identities[0]).toMatchObject({ type: 'github', value: 'bocon13' })
-    expect(identities[1]).toMatchObject({
-      type: 'email',
-      value: 'bocon@opennetworking.org'
-    })
+    expect(identities.length).toBe(2)
+    expect(identities[0]).toBe(mockIdentities[0])
+    expect(identities[1]).toBe(mockIdentities[1])
   })
 
-  test('CLA not signed for PR with one commit', async () => {
-    cla.checkIdentities = checkIdentifiesFail
+  test('PR request should be stored in the db after a pull request event', async () => {
+    await github.receive({ name: 'pull_request', payload })
+    const request = (await requestsRef.get()).docs[0].data()
+    expect(request).toMatchObject(request)
+  })
+
+  test('PR request should fail validation', async () => {
     nock('https://api.github.com')
-      .post('/repos/bocon13/cla-test/statuses/2129e453f6d652badfb353c510a3669873a15f7c',
+      .post(statusUri,
         (body) => {
           expect(body.state).toEqual('failure')
           return true
         })
       .reply(200)
-    expect.assertions(1)
-    // Receive a webhook event
-    await github.receive({ name: 'pull_request', payload })
+    const snapshot = await addAndGetSnapshot(requestsRef, mockRequest)
+    await github.processRequest(snapshot)
+    const updatedRequest = (await snapshot.ref.get()).data()
+    expect(updatedRequest.lastStatus.state).toBe('failure')
+    expect(updatedRequest.lastStatus.octoAck).toBe(true)
+    expect(updatedRequest.processedCount).toBe(1)
+    expect.assertions(4)
   })
 
-  test('CLA signed for PR with one commit', async () => {
-    cla.checkIdentities = checkIdentifiesSuccess
+  test('PR request should fail CLA validation if only some identities are not whitelisted', async () => {
+    // Only one of the requested entities is in the db.
+    await db.collection('whitelists').add({
+      values: mockIdentities[0]
+    })
     nock('https://api.github.com')
-      .post('/repos/bocon13/cla-test/statuses/2129e453f6d652badfb353c510a3669873a15f7c',
+      .post(statusUri,
+        (body) => {
+          expect(body.state).toEqual('failure')
+          // The missing one should be mentioned in the status.
+          expect(body.description).toContain(mockIdentities[1])
+          return true
+        })
+      .reply(200)
+    const snapshot = await addAndGetSnapshot(requestsRef, mockRequest)
+    await github.processRequest(snapshot)
+    const updatedRequest = (await snapshot.ref.get()).data()
+    expect(updatedRequest.lastStatus.state).toBe('failure')
+    expect(updatedRequest.lastStatus.octoAck).toBe(true)
+    expect.assertions(4)
+  })
+
+  test('PR request should be successfully validated', async () => {
+    // All requested identities are in the whitelist.
+    await db.collection('whitelists').add({
+      values: mockIdentities
+    })
+    nock('https://api.github.com')
+      .post(statusUri,
         (body) => {
           expect(body.state).toEqual('success')
           return true
         })
       .reply(200)
-    expect.assertions(1)
-    // Receive a webhook event
-    await github.receive({ name: 'pull_request', payload })
+    const snapshot = await addAndGetSnapshot(requestsRef, mockRequest)
+    await github.processRequest(snapshot)
+    const updatedRequest = (await snapshot.ref.get()).data()
+    expect(updatedRequest.lastStatus.state).toBe('success')
+    expect(updatedRequest.lastStatus.octoAck).toBe(true)
+    expect.assertions(3)
   })
 
-  test('Fail on 300 commits', async () => {
+  test('PR request should be updated when posting github status fails', async () => {
     nock('https://api.github.com')
-      .post('/repos/bocon13/cla-test/statuses/2129e453f6d652badfb353c510a3669873a15f7c',
+      .post(statusUri,
         (body) => {
-          expect(body.state).toEqual('failure')
+          return true
+        })
+      .reply(404)
+    const snapshot = await addAndGetSnapshot(requestsRef, mockRequest)
+    await github.processRequest(snapshot)
+    const updatedRequest = (await snapshot.ref.get()).data()
+    expect(updatedRequest.lastStatus.octoAck).toBe(false)
+    expect(updatedRequest.lastStatus.octoError.status).toBe(404)
+  })
+
+  test('PR request should error if it exceeds the commit limit', async () => {
+    nock('https://api.github.com')
+      .post(statusUri,
+        (body) => {
+          expect(body.state).toEqual('error')
+          // The user should see mention of the limit.
           expect(body.description).toContain('250')
           return true
         })
       .reply(200)
-    expect.assertions(2)
-    // Receive a webhook event
-    await github.receive({ name: 'pull_request', payload: hugePayload })
+    const hugeRequest = JSON.parse(JSON.stringify(mockRequest))
+    hugeRequest.payload = hugePayload
+    const snapshot = await addAndGetSnapshot(requestsRef, hugeRequest)
+    await github.processRequest(snapshot)
+    const updatedRequest = (await snapshot.ref.get()).data()
+    expect(updatedRequest.lastStatus.state).toBe('error')
+    expect(updatedRequest.lastStatus.octoAck).toBe(true)
+    expect.assertions(4)
+  })
+
+  test('PR request should fail if identities are empty', async () => {
+    nock('https://api.github.com')
+      .post(statusUri,
+        (body) => {
+          expect(body.state).toEqual('error')
+          // The user should see mention of the issue.
+          expect(body.description).toContain('empty')
+          return true
+        })
+      .reply(200)
+    const req = JSON.parse(JSON.stringify(mockRequest))
+    req.identities = []
+    const snapshot = await addAndGetSnapshot(requestsRef, req)
+    await github.processRequest(snapshot)
+    const updatedRequest = (await snapshot.ref.get()).data()
+    expect(updatedRequest.lastStatus.state).toBe('error')
+    expect(updatedRequest.lastStatus.octoAck).toBe(true)
+    expect.assertions(4)
   })
 })

--- a/functions/test/helpers.js
+++ b/functions/test/helpers.js
@@ -5,10 +5,13 @@ const firebase = require('@firebase/testing')
  * pre-populated with the given data.
  * @param {{ uid: String, email: String }} auth identifiers
  * @param data {Object|null}
+ * @param projectId {string|null}
  * @returns {Promise<FirebaseFirestore.Firestore>}
  */
-module.exports.setupDb = async (auth, data) => {
-  const projectId = `test-${Date.now()}`
+module.exports.setupDb = async (auth, data, projectId = null) => {
+  if (!projectId) {
+    projectId = `test-${Date.now()}`
+  }
   let app
   if (auth) {
     app = await firebase.initializeTestApp({
@@ -46,10 +49,23 @@ module.exports.setupDb = async (auth, data) => {
 /**
  * Returns a firestore instance that can be accessed as admin, optionally populated with the given data object.
  * @param {Object|null} data
+ *  * @param projectId {string|null}
  * @returns {Promise<FirebaseFirestore.Firestore>}
  */
-module.exports.setupDbAdmin = async (data) => {
+module.exports.setupDbAdmin = async (data, projectId = null) => {
   return module.exports.setupDb(null, data)
+}
+
+/**
+ * Clears all data associated with a particular project in the locally running
+ * Firestore instance. Use this method to clean-up after tests.
+ * @param projectId {string}
+ * @returns {Promise<void>}
+ */
+module.exports.clearDb = async (projectId) => {
+  return firebase.clearFirestoreData({
+    projectId: projectId
+  })
 }
 
 module.exports.teardownDb = async () => {

--- a/functions/test/run.sh
+++ b/functions/test/run.sh
@@ -1,4 +1,0 @@
-#!/usr/bin/env bash
-set -e
-
-jest

--- a/functions/test/util.test.js
+++ b/functions/test/util.test.js
@@ -1,0 +1,36 @@
+import { identityKey, identityObj } from '../lib/util'
+
+describe('Util lib', () => {
+  it('should produce valid identity keys and objects', async () => {
+    expect(identityKey({ type: 'foo', value: 'bar' }))
+      .toEqual('foo:bar')
+    expect(identityKey({ type: 'foo', value: 'BAR' }))
+      .toEqual('foo:bar')
+    expect(identityKey({ type: 'foo', value: 'bar', fubar: 'fubar' }))
+      .toEqual('foo:bar')
+    expect(identityObj('foo:bar'))
+      .toMatchObject({ type: 'foo', value: 'bar' })
+    expect(identityObj('foo:bar:bar'))
+      .toMatchObject({ type: 'foo', value: 'bar:bar' })
+
+    expect(() => identityKey())
+      .toThrow(Error)
+    expect(() => identityKey({}))
+      .toThrow(Error)
+    expect(() => identityKey({ type: 'foo', bar: 'bar' }))
+      .toThrow(Error)
+    expect(() => identityKey({ foo: 'foo', value: 'bar' }))
+      .toThrow(Error)
+    expect(() => identityKey({ type: 'foo', bar: 'bar' }))
+      .toThrow(Error)
+
+    expect(() => identityObj())
+      .toThrow(Error)
+    expect(() => identityObj(''))
+      .toThrow(Error)
+    expect(() => identityObj({ an: 'object' }))
+      .toThrow(Error)
+    expect(() => identityObj('noseparator'))
+      .toThrow(Error)
+  })
+})


### PR DESCRIPTION
The payload of a PR webook is now stored in the DB and processed
asynchronously. This allows us to keep track of PRs that are not covered
by a CLA. When a new addendum is added and the whitelist updated, we can
scan for all pending requests and process them right away, without any
extra actions from users (TODO).