### PR TITLE
Rework github webhook to handle events asynchronously

### DIFF
--- a/functions/index.js
+++ b/functions/index.js
@@ -1,45 +1,56 @@
 const admin = require('firebase-admin')
 const functions = require('firebase-functions')
-admin.initializeApp(functions.config().firebase)
-const db = admin.firestore()
-
 const Github = require('./lib/github')
 const Cla = require('./lib/cla')
+
+admin.initializeApp(functions.config().firebase)
+const db = admin.firestore()
 
 const clalib = new Cla(db)
 const github = new Github(
   functions.config().github.app_id,
   functions.config().github.key,
   functions.config().github.secret,
-  clalib)
-
-exports.githubWebook = functions.https.onRequest(github.handler)
-
-// Add functions in response to DB changes
-// https://firebase.google.com/docs/firestore/extend-with-functions
-
-// exports.modifyUser = functions.firestore
-//   .document('clas/{claID}')
-//   .onWrite((change) => {
-//     // Get an object with the current document value.
-//     // If the document does not exist, it has been deleted.
-//     const document = change.after.exists ? change.after.data() : null
-//
-//     // Get an object with the previous document value (for update or delete)
-//     // const oldDocument = change.before.toJson()
-//
-//     // Check to see if there are any outstanding PRs for newly added users
-//     if (document) {
-//       const whitelist = document.data().whitelist
-//       console.log('rechecking', whitelist)
-//       // TODO: re-enable once recheckPrsForEmails is fixed
-//       // github.recheckPrsForEmails(whitelist)
-//     }
-//   })
+  db)
 
 /**
- * When a new addendum is created, update the list of active contributors in the parent agreement.
+ * When a new addendum is created, update the whitelists collection with the
+ * list of allowed identities for the parent agreement.
  */
 exports.updateWhitelist = functions.firestore
   .document('/addendums/{id}')
   .onCreate(clalib.updateWhitelist)
+
+/**
+ * Handles GitHub pull requests and other events. For pull requests, the
+ * implementation is expected to create a new request document in the DB, which
+ * will be picked up by the below function.
+ */
+exports.githubWebook = functions.https.onRequest(github.handler)
+
+/**
+ * When a new CLA validation event is created, e.g. by the GitHub webhook,
+ * process it. The implementation is expected to update the status of the
+ * contribution (e.g., GitHub PR) in the corresponding server and wait for an
+ * ack. Event documents should be updated in the DB with an indication if the
+ * ack was successful or if any error occurred.
+ */
+exports.handleEvent = functions.firestore
+  .document('/events/{id}')
+  .onCreate(snapshot => {
+    const event = snapshot.data()
+    if (!('provider' in event)) {
+      return Promise.reject(new Error('missing provider key in request'))
+    }
+    if (event.provider === 'github') {
+      return github.processEvent(snapshot)
+    } else {
+      return Promise.reject(new Error(`unknown request type ${event.type}`))
+    }
+  })
+
+// TODO: implement cronjob function to periodically clean up acknowledged and
+//  outdated events.
+
+// TODO: implement logic to re-process any pending event every time the
+//  whitelists collection is updated.

--- a/functions/lib/github.js
+++ b/functions/lib/github.js
@@ -182,8 +182,13 @@ function Github (appId, privateKey, secret, db) {
           commentData.comment_id = commentId
           return octokit.issues.deleteComment(commentData)
         }
+        return Promise.resolve()
       })
       .then(response => {
+        if (!response) {
+          // We didn't post any comment
+          return Promise.resolve()
+        }
         // Update comment ID in contribution doc
         let commentId
         switch (response.status) {

--- a/functions/lib/github.js
+++ b/functions/lib/github.js
@@ -156,7 +156,7 @@ function Github (appId, privateKey, secret, db) {
       .then(snapshot => {
         // Retrieve existing comment_id (if any)
         if (!snapshot.exists) {
-          console.error(`Missing contribution ${event.contributionId} in DB`)
+          console.warn(`Missing contribution ${event.contributionId} in DB`)
           return null
         } else {
           return snapshot.data().githubCommentId

--- a/functions/lib/util.js
+++ b/functions/lib/util.js
@@ -1,0 +1,34 @@
+/**
+ * Returns a string that uniquely identifies the given identity object.
+ * @param identityObj {{type: string, value: string}}
+ * @returns {string}
+ */
+module.exports.identityKey = function (identityObj) {
+  if (!identityObj || !('type' in identityObj) || !('value' in identityObj)) {
+    throw new Error('Invalid identity object')
+  }
+  const lcValue = identityObj.value.toLowerCase()
+  return `${identityObj.type}:${lcValue}`
+}
+
+/**
+ * Returns an identity object with type and value from the given key.
+ * @param identityKey {string}
+ * @returns {{type: string, value: string}}
+ */
+module.exports.identityObj = function (identityKey) {
+  if (!identityKey) {
+    throw new Error('Identity key is falsy')
+  }
+  if (!(typeof identityKey === 'string' || identityKey instanceof String)) {
+    throw new Error('Invalid identity key is not a string')
+  }
+  const i = identityKey.indexOf(':')
+  if (i < 0) {
+    throw new Error('Invalid identity key')
+  }
+  return {
+    type: identityKey.slice(0, i),
+    value: identityKey.slice(i + 1)
+  }
+}

--- a/functions/package.json
+++ b/functions/package.json
@@ -17,14 +17,15 @@
     "deploy": "npx firebase deploy --only functions",
     "logs": "npx firebase functions:log",
     "pretest": "npm run lint",
-    "test": "npx firebase emulators:exec --only firestore 'test/run.sh'"
+    "test": "npx firebase emulators:exec --only firestore 'jest'"
   },
   "dependencies": {
     "@octokit/app": "^2.2.5",
     "@octokit/rest": "^16.43.0",
     "@octokit/webhooks": "^6.3.2",
     "firebase-admin": "^8.9.2",
-    "firebase-functions": "^3.3.0"
+    "firebase-functions": "^3.3.0",
+    "sha1": "^1.1.1"
   },
   "devDependencies": {
     "@babel/preset-env": "^7.8.3",

--- a/functions/test/github.test.js
+++ b/functions/test/github.test.js
@@ -38,7 +38,7 @@ describe('Github lib', () => {
   let mockEvent
   let payload
 
-  beforeAll(async (done) => {
+  beforeAll((done) => {
     fs.readFile(path.join(__dirname, 'fixtures/mock-cert.pem'), (err, cert) => {
       if (err) return done(err)
       mockCert = cert.toString()

--- a/functions/test/github.test.js
+++ b/functions/test/github.test.js
@@ -38,7 +38,7 @@ describe('Github lib', () => {
   let mockEvent
   let payload
 
-  beforeAll((done) => {
+  beforeAll(async (done) => {
     fs.readFile(path.join(__dirname, 'fixtures/mock-cert.pem'), (err, cert) => {
       if (err) return done(err)
       mockCert = cert.toString()

--- a/functions/test/github.test.js
+++ b/functions/test/github.test.js
@@ -1,121 +1,223 @@
+import {
+  addAndGetSnapshot,
+  setAndGetSnapshot,
+  setupDbAdmin,
+  teardownDb
+} from './helpers'
+
+const sha1 = require('sha1')
 const nock = require('nock')
 const fs = require('fs')
 const path = require('path')
 
-const Octokit = require('@octokit/rest')
-
-// Requiring our app implementation
 const Github = require('../lib/github')
+const prOpenedPayload = require('./fixtures/pull_request.opened')
 
-// Requiring our fixtures
-const payload = require('./fixtures/pull_request.opened')
-const hugePayload = require('./fixtures/pull_request.opened.huge')
-const commits = require('./fixtures/commits')
+const contributionKey = 'github.com/bocon13/cla-test/pull/3'
+const contributionId = sha1(contributionKey)
+const identity = 'github:bocon13'
 
-const checkIdentifiesSuccess = async () => {
-  return Promise.resolve({
-    allWhitelisted: true,
-    missingIdentities: []
-  })
-}
+const githubApi = 'https://api.github.com'
+const statusUri = '/repos/bocon13/cla-test/statuses/2129e453f6d652badfb353c510a3669873a15f7c'
+const createCommentUri = '/repos/bocon13/cla-test/issues/3/comments'
+const existingCommentUri = '/repos/bocon13/cla-test/issues/comments/1'
 
-const checkIdentifiesFail = async () => {
-  return Promise.resolve({
-    allWhitelisted: false,
-    missingIdentities: []
-  })
-}
+const appId = 123
+const projectId = 'github-test-' + new Date()
 
 nock.disableNetConnect()
 
-describe('Github PR Webhook', () => {
-  const appId = 123
+describe('Github lib', () => {
+  let db
   let github
+  let contribsRef
+  let eventsRef
+  let whitelistsRef
   let mockCert
-  const cla = {
-    checkIdentities: checkIdentifiesSuccess
-  }
+  let mockContribution
+  let mockEvent
+  let payload
 
-  beforeAll((done) => {
+  beforeAll(async (done) => {
     fs.readFile(path.join(__dirname, 'fixtures/mock-cert.pem'), (err, cert) => {
       if (err) return done(err)
-      mockCert = cert
+      mockCert = cert.toString()
       return done()
     })
   })
 
-  beforeEach(() => {
-    github = new Github(appId, mockCert, 'secret', cla)
+  beforeEach(async () => {
+    db = await setupDbAdmin(null, projectId)
+    contribsRef = db.collection('contributions')
+    eventsRef = db.collection('events')
+    whitelistsRef = db.collection('whitelists')
+    github = new Github(appId, mockCert, 'secret', db)
     // Return a token for fake application (id=555)
-    nock('https://api.github.com')
-      .post('/app/installations/555/access_tokens')
-      .reply(200, { token: 'test' })
-    // Return the list of commits for PR #3
-    nock('https://api.github.com')
-      .get('/repos/bocon13/cla-test/pulls/3/commits')
-      .reply(200, commits)
+    nock(githubApi).post('/app/installations/555/access_tokens')
+      .reply(201, { token: 'test' })
+    // Make a copy so we can modify it in each test
+    payload = JSON.parse(JSON.stringify(prOpenedPayload))
+    mockContribution = {
+      key: contributionKey,
+      provider: 'github',
+      project: 'bocon13/cla-test',
+      type: 'pull_request'
+    }
+    mockEvent = {
+      contributionId: contributionId,
+      contributionKey: contributionKey,
+      provider: 'github',
+      type: 'pull_request.opened',
+      payload: payload
+    }
   })
 
-  test('PR identities can be extracted', async () => {
-    const ghClient = new Octokit({ auth: 'accesstoken' })
-    const identities = await github.getPrIdentities(payload.pull_request, ghClient)
-    expect(identities[0]).toMatchObject({ type: 'github', value: 'bocon13' })
-    expect(identities[1]).toMatchObject({ type: 'github', value: 'bocon13' })
-    expect(identities[2]).toMatchObject({
-      type: 'email',
-      value: 'bocon@opennetworking.org'
+  afterAll(() => {
+    return teardownDb()
+  })
+
+  test('PR open event should be stored in the db', async () => {
+    await github.receive({ name: 'pull_request', payload: payload })
+    const contribution = (await contribsRef.get()).docs[0].data()
+    const event = (await eventsRef.get()).docs[0].data()
+    expect(contribution).toMatchObject(mockContribution)
+    expect(event).toMatchObject(mockEvent)
+  })
+
+  test('Handle PR synchronize events', async () => {
+    payload.action = 'synchronize'
+    mockEvent.payload = payload
+    mockEvent.type = 'pull_request.synchronize'
+    await github.receive({ name: 'pull_request', payload: payload })
+    const event = (await eventsRef.get()).docs[0].data()
+    // Contribution should not be stored.
+    expect((await contribsRef.doc(contributionId).get()).exists).toBe(false)
+    // Just the event.
+    expect(event).toMatchObject(mockEvent)
+  })
+
+  test('Handle PR close events', async () => {
+    payload.action = 'closed'
+    mockEvent.payload = payload
+    mockEvent.type = 'pull_request.closed'
+    await setAndGetSnapshot(contribsRef, mockContribution, contributionId)
+    await github.receive({ name: 'pull_request', payload: payload })
+    expect((await contribsRef.get()).docs.length).toBe(0)
+    expect((await eventsRef.get()).docs.length).toBe(0)
+  })
+
+  test('PR should fail validation if identity is not whitelisted', async () => {
+    nock(githubApi).post(statusUri, (body) => {
+      expect(body.state).toEqual('failure')
+      return true
+    }).reply(201)
+    nock(githubApi).post(createCommentUri, (req) => {
+      // console.log(`CREATE COMMENT => ${req.body}`)
+      expect(req.body.length).toBeGreaterThan(0)
+      return true
+    }).reply(201, { id: 1 })
+    const contribSnapshot = await setAndGetSnapshot(contribsRef, mockContribution, contributionId)
+    const eventSnapshot = await addAndGetSnapshot(eventsRef, mockEvent)
+    await github.processEvent(eventSnapshot)
+    const updatedContrib = (await contribSnapshot.ref.get()).data()
+    const updatedEvent = (await eventSnapshot.ref.get()).data()
+    expect(updatedEvent.status.state).toBe('failure')
+    expect(updatedEvent.status.description.length).toBeLessThanOrEqual(140)
+    expect(updatedEvent.status.githubAck).toBe(true)
+    expect(updatedEvent.status.githubError).toBeFalsy()
+    expect(updatedContrib.githubCommentId).toBe(1)
+    expect.assertions(7)
+  })
+
+  test('PR should be validated if identity is whitelisted', async () => {
+    await whitelistsRef.add({
+      values: [identity]
     })
-    expect(true)
+    nock(githubApi).post(statusUri, (body) => {
+      expect(body.state).toEqual('success')
+      return true
+    }).reply(201)
+    const contribSnapshot = await setAndGetSnapshot(contribsRef, mockContribution, contributionId)
+    const eventSnapshot = await addAndGetSnapshot(eventsRef, mockEvent)
+    await github.processEvent(eventSnapshot)
+    const updatedContrib = (await contribSnapshot.ref.get()).data()
+    const updatedEvent = (await eventSnapshot.ref.get()).data()
+    expect(updatedEvent.status.state).toBe('success')
+    expect(updatedEvent.status.description.length).toBeLessThanOrEqual(140)
+    expect(updatedEvent.status.githubAck).toBe(true)
+    expect(updatedEvent.status.githubError).toBeFalsy()
+    expect(updatedContrib.githubCommentId).toBeFalsy()
+    expect.assertions(6)
   })
 
-  test('Commit identities can be extracted', async () => {
-    const identities = github.getCommitIdentities(commits[0])
-    expect(identities[0]).toMatchObject({ type: 'github', value: 'bocon13' })
-    expect(identities[1]).toMatchObject({
-      type: 'email',
-      value: 'bocon@opennetworking.org'
+  test('PR should be updated with error when posting status fails', async () => {
+    nock(githubApi).post(statusUri, (body) => {
+      return true
+    }).reply(500)
+    nock(githubApi).post(createCommentUri, (req) => {
+      // console.log(`CREATE COMMENT => ${req.body}`)
+      expect(req.body.length).toBeGreaterThan(0)
+      return true
+    }).reply(201, { id: 1 })
+    await setAndGetSnapshot(contribsRef, mockContribution, contributionId)
+    const eventSnapshot = await addAndGetSnapshot(eventsRef, mockEvent)
+    await github.processEvent(eventSnapshot)
+    const updatedEvent = (await eventSnapshot.ref.get()).data()
+    expect(updatedEvent.status.githubAck).toBe(false)
+    expect(updatedEvent.status.githubError.status).toBe(500)
+    expect.assertions(3)
+  })
+
+  test('existing comments get removed after a PR is validated', async () => {
+    await whitelistsRef.add({
+      values: [identity]
     })
+    nock(githubApi).post(statusUri, (body) => {
+      expect(body.state).toEqual('success')
+      return true
+    }).reply(201)
+    nock(githubApi).delete(existingCommentUri, () => {
+      expect(true).toBe(true)
+      return true
+    }).reply(204)
+    // Set existing comment ID
+    mockContribution.githubCommentId = 1
+    const contribSnapshot = await setAndGetSnapshot(contribsRef, mockContribution, contributionId)
+    const eventSnapshot = await addAndGetSnapshot(eventsRef, mockEvent)
+    await github.processEvent(eventSnapshot)
+    const updatedContrib = (await contribSnapshot.ref.get()).data()
+    const updatedEvent = (await eventSnapshot.ref.get()).data()
+    expect(updatedEvent.status.state).toBe('success')
+    expect(updatedEvent.status.description.length).toBeLessThanOrEqual(140)
+    expect(updatedEvent.status.githubAck).toBe(true)
+    expect(updatedEvent.status.githubError).toBeFalsy()
+    expect(updatedEvent.status.comment).toBeFalsy()
+    expect(updatedContrib.githubCommentId).toBeFalsy()
+    expect.assertions(8)
   })
 
-  test('CLA not signed for PR with one commit', async () => {
-    cla.checkIdentities = checkIdentifiesFail
-    nock('https://api.github.com')
-      .post('/repos/bocon13/cla-test/statuses/2129e453f6d652badfb353c510a3669873a15f7c',
-        (body) => {
-          expect(body.state).toEqual('failure')
-          return true
-        })
-      .reply(200)
-    expect.assertions(1)
-    // Receive a webhook event
-    await github.receive({ name: 'pull_request', payload })
-  })
-
-  test('CLA signed for PR with one commit', async () => {
-    cla.checkIdentities = checkIdentifiesSuccess
-    nock('https://api.github.com')
-      .post('/repos/bocon13/cla-test/statuses/2129e453f6d652badfb353c510a3669873a15f7c',
-        (body) => {
-          expect(body.state).toEqual('success')
-          return true
-        })
-      .reply(200)
-    expect.assertions(1)
-    // Receive a webhook event
-    await github.receive({ name: 'pull_request', payload })
-  })
-
-  test('Fail on 300 commits', async () => {
-    nock('https://api.github.com')
-      .post('/repos/bocon13/cla-test/statuses/2129e453f6d652badfb353c510a3669873a15f7c',
-        (body) => {
-          expect(body.state).toEqual('failure')
-          expect(body.description).toContain('250')
-          return true
-        })
-      .reply(200)
-    expect.assertions(2)
-    // Receive a webhook event
-    await github.receive({ name: 'pull_request', payload: hugePayload })
+  test('existing PR comments get updated', async () => {
+    nock(githubApi).post(statusUri, (body) => {
+      expect(body.state).toEqual('failure')
+      return true
+    }).reply(201)
+    nock(githubApi).patch(existingCommentUri, (req) => {
+      // console.log(`UPDATE COMMENT => ${req.body}`)
+      expect(req.body.length).toBeGreaterThan(0)
+      return true
+    }).reply(200, { id: 1 })
+    // Set existing comment ID
+    mockContribution.githubCommentId = 1
+    const contribSnapshot = await setAndGetSnapshot(contribsRef, mockContribution, contributionId)
+    const eventSnapshot = await addAndGetSnapshot(eventsRef, mockEvent)
+    await github.processEvent(eventSnapshot)
+    const updatedContrib = (await contribSnapshot.ref.get()).data()
+    const updatedEvent = (await eventSnapshot.ref.get()).data()
+    expect(updatedEvent.status.state).toBe('failure')
+    expect(updatedEvent.status.description.length).toBeLessThanOrEqual(140)
+    expect(updatedEvent.status.githubAck).toBe(true)
+    expect(updatedEvent.status.githubError).toBeFalsy()
+    expect(updatedContrib.githubCommentId).toBe(1)
+    expect.assertions(7)
   })
 })

--- a/functions/test/helpers.js
+++ b/functions/test/helpers.js
@@ -1,14 +1,17 @@
 const firebase = require('@firebase/testing')
 
 /**
- * Returns a firestore instance that can be accessed as the user defined in the given auth object, optionally
- * pre-populated with the given data.
+ * Returns a firestore instance that can be accessed as the user defined in the
+ * given auth object, optionally pre-populated with the given data.
  * @param {{ uid: String, email: String }} auth identifiers
  * @param data {Object|null}
+ * @param projectId {string|null}
  * @returns {Promise<FirebaseFirestore.Firestore>}
  */
-module.exports.setupDb = async (auth, data) => {
-  const projectId = `test-${Date.now()}`
+module.exports.setupDb = async (auth, data, projectId = null) => {
+  if (!projectId) {
+    projectId = `test-${Date.now()}`
+  }
   let app
   if (auth) {
     app = await firebase.initializeTestApp({
@@ -44,12 +47,26 @@ module.exports.setupDb = async (auth, data) => {
 }
 
 /**
- * Returns a firestore instance that can be accessed as admin, optionally populated with the given data object.
+ * Returns a firestore instance that can be accessed as admin, optionally
+ * populated with the given data object.
  * @param {Object|null} data
+ * @param projectId {string|null}
  * @returns {Promise<FirebaseFirestore.Firestore>}
  */
-module.exports.setupDbAdmin = async (data) => {
+module.exports.setupDbAdmin = async (data, projectId = null) => {
   return module.exports.setupDb(null, data)
+}
+
+/**
+ * Clears all data associated with a particular project in the locally running
+ * Firestore instance. Use this method to clean-up after tests.
+ * @param projectId {string}
+ * @returns {Promise<void>}
+ */
+module.exports.clearDb = async (projectId) => {
+  return firebase.clearFirestoreData({
+    projectId: projectId
+  })
 }
 
 module.exports.teardownDb = async () => {
@@ -58,6 +75,10 @@ module.exports.teardownDb = async () => {
 
 module.exports.addAndGetSnapshot = async (collectionRef, document) => {
   return collectionRef.add(document).then(res => res.get())
+}
+
+module.exports.setAndGetSnapshot = async (collectionRef, document, id) => {
+  return collectionRef.doc(id).set(document).then(() => collectionRef.doc(id).get())
 }
 
 expect.extend({

--- a/functions/test/run.sh
+++ b/functions/test/run.sh
@@ -1,4 +1,0 @@
-#!/usr/bin/env bash
-set -e
-
-jest

--- a/functions/test/util.test.js
+++ b/functions/test/util.test.js
@@ -1,0 +1,36 @@
+import { identityKey, identityObj } from '../lib/util'
+
+describe('Util lib', () => {
+  it('should produce valid identity keys and objects', async () => {
+    expect(identityKey({ type: 'foo', value: 'bar' }))
+      .toEqual('foo:bar')
+    expect(identityKey({ type: 'foo', value: 'BAR' }))
+      .toEqual('foo:bar')
+    expect(identityKey({ type: 'foo', value: 'bar', fubar: 'fubar' }))
+      .toEqual('foo:bar')
+    expect(identityObj('foo:bar'))
+      .toMatchObject({ type: 'foo', value: 'bar' })
+    expect(identityObj('foo:bar:bar'))
+      .toMatchObject({ type: 'foo', value: 'bar:bar' })
+
+    expect(() => identityKey())
+      .toThrow(Error)
+    expect(() => identityKey({}))
+      .toThrow(Error)
+    expect(() => identityKey({ type: 'foo', bar: 'bar' }))
+      .toThrow(Error)
+    expect(() => identityKey({ foo: 'foo', value: 'bar' }))
+      .toThrow(Error)
+    expect(() => identityKey({ type: 'foo', bar: 'bar' }))
+      .toThrow(Error)
+
+    expect(() => identityObj())
+      .toThrow(Error)
+    expect(() => identityObj(''))
+      .toThrow(Error)
+    expect(() => identityObj({ an: 'object' }))
+      .toThrow(Error)
+    expect(() => identityObj('noseparator'))
+      .toThrow(Error)
+  })
+})


### PR DESCRIPTION
PR webooks are now stored in the DB and processed asynchronously. This
allows us to keep track of PRs that are not covered by a CLA. When a new
addendum is added and the whitelist updated, we can scan for all pending
requests and process them right away, without any additional action from
users. That has yet to be implemented, but the database schema is in
place.

Two new collections are maintained: (1) contributions, and (2) events.
One contribution is created for each PR, while an event is created for
each PR webhook action (open, synchronize, close, reopen).

When processing events, the implementation checks the whitelists for the
PR author and updates the PR status, eventually posting a comment in
case a user action is needed, e.g. asking to sing a CLA, or for errors.