### PR TITLE
Re-process pending validation events as a consequence of whitelist updates

### DIFF
--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -13,6 +13,20 @@
           "order": "ASCENDING"
         }
       ]
+    },
+    {
+      "collectionGroup": "events",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "status.state",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "identity",
+          "order": "ASCENDING"
+        }
+      ]
     }
   ],
   "fieldOverrides": []

--- a/functions/package.json
+++ b/functions/package.json
@@ -25,6 +25,7 @@
     "@octokit/webhooks": "^6.3.2",
     "firebase-admin": "^8.9.2",
     "firebase-functions": "^3.3.0",
+    "lodash": "^4.17.15",
     "sha1": "^1.1.1"
   },
   "devDependencies": {


### PR DESCRIPTION
This patch adds a new function that listen for changes to the whitelists
and re-process Github PR events that match the added identities,
eventually updating the PR status.