### PR TITLE
Updating firestore.rules

### DIFF
--- a/client/src/js/SignIn.jsx
+++ b/client/src/js/SignIn.jsx
@@ -105,7 +105,7 @@ export default function SignIn () {
               autoFocus
             />
             <p>
-              If you are already registered, please enter the email address you used to register with the ONF CLA portal.
+              If you are already registered, please enter the email address you used to register with the ONF CLA Portal.
               Click the button to receive a link to view your ONF CLA information.
               <br/><br/>
               If you have not yet registered, please enter the email address you wish to use to register with the ONF CLA Portal.

--- a/client/src/js/addendum/AddendumContainer.jsx
+++ b/client/src/js/addendum/AddendumContainer.jsx
@@ -41,7 +41,7 @@ function AddendumContainer (props) {
   const [openDialog, setOpenDialog] = useState(false)
 
   useEffect(() => {
-    Addendum.get(props.agreementId)
+    Addendum.get(props.agreementId, props.user.email)
       .then(res => {
         // go from whatever Firebase returns to a real array
         // TODO consider to move this in the models

--- a/common/model/addendum.js
+++ b/common/model/addendum.js
@@ -123,9 +123,9 @@ class addendum {
   }
 
   // NOTE should we return instances of the class?
-  static get (agreementId) {
+  static get (agreementId, signerEmail) {
     return DB.connection().collection(addendumCollection)
-      .where('signer.value', '==', this.signer.value)
+      .where('signer.value', '==', signerEmail)
       .where('agreementId', '==', agreementId)
       .orderBy('dateSigned')
       .get()

--- a/common/model/addendum.js
+++ b/common/model/addendum.js
@@ -125,7 +125,7 @@ class addendum {
   // NOTE should we return instances of the class?
   static get (agreementId) {
     return DB.connection().collection(addendumCollection)
-      .where("signer.value", "==", this.signer.value)
+      .where('signer.value', '==', this.signer.value)
       .where('agreementId', '==', agreementId)
       .orderBy('dateSigned')
       .get()

--- a/common/model/addendum.js
+++ b/common/model/addendum.js
@@ -125,6 +125,7 @@ class addendum {
   // NOTE should we return instances of the class?
   static get (agreementId) {
     return DB.connection().collection(addendumCollection)
+      .where("signer.value", "==", this.signer.value)
       .where('agreementId', '==', agreementId)
       .orderBy('dateSigned')
       .get()

--- a/common/model/agreement.js
+++ b/common/model/agreement.js
@@ -155,7 +155,7 @@ class agreement {
    * @returns {Promise<Addendum[]>}
    */
   getAddendums () {
-    return Addendum.get(this.id)
+    return Addendum.get(this.id, this.signer.value)
   }
 
   /**

--- a/common/model/agreement.test.js
+++ b/common/model/agreement.test.js
@@ -116,6 +116,7 @@ describe('The Agreement model', () => {
       }
       individualAgreement.getAddendums()
         .then(res => {
+          expect(firestoreMock.mockWhere).toBeCalledWith('signer.value', '==', signer.value)
           expect(firestoreMock.mockWhere).toBeCalledWith('agreementId', '==', null)
           expect(res.docs.length).toEqual(2)
           expect(res.docs[0].data().added.length).toEqual(2)

--- a/firestore.rules
+++ b/firestore.rules
@@ -11,7 +11,7 @@ function didSign() {
 // Note: CLAs and Addendums cannot be modified or deleted
 service cloud.firestore {
   match /databases/{database}/documents {
-    match /agreements/{cla} {
+    match /agreements/{agreementId} {
       allow create: if request.auth != null && isSigner();
       allow read:   if request.auth != null && didSign(); //TODO (see below #2)
       allow update: if false;

--- a/firestore.rules
+++ b/firestore.rules
@@ -1,28 +1,49 @@
+// Checks to see if the signer of the new CLA or Addendum is the authenticated user
 function isSigner() {
-	return request.auth.token.email == resource.data.signer.value;
+  return request.auth.token.email == request.resource.data.signer.value;
 }
 
-function isAdmin() {
-	return request.auth.token.email in resource.data.admins || isSigner();
+// Checks to see if the signer of the existing CLA or Addendum is the authenticated user
+function didSign() {
+  return request.auth.token.email == resource.data.signer.value;
 }
 
-function onWhitelist() {
-	return request.auth.token.email == resource.data.signer.value || isAdmin();
-}
-
+// Note: CLAs and Addendums cannot be modified or deleted
 service cloud.firestore {
   match /databases/{database}/documents {
     match /agreements/{cla} {
-      allow read: if request.auth != null && onWhitelist();
-      allow update: if request.auth != null && isAdmin();
-      allow create: if request.auth != null && request.auth.token.email == request.resource.data.signer.value;
-      allow delete: if request.auth != null && isSigner();
+      allow create: if request.auth != null && isSigner();
+      allow read:   if request.auth != null && didSign(); //TODO (see below #2)
+      allow update: if false;
+      allow delete: if false;
     }
     match /addendums/{addendumId} {
-      allow read: if true;
-      allow create: if true;
-      allow delete: if false;
+      allow create: if request.auth != null && isSigner() &&
+        get(/databases/$(database)/documents/agreements/$(request.resource.data.agreementId)).data.signer.value
+          == request.resource.data.signer.value; //TODO (see below #1)
+      allow read:   if request.auth != null && didSign(); //TODO (see below #2)
       allow update: if false;
+      allow delete: if false;
     }
   }
 }
+
+/* Notes:
+
+Today, only the signer of an agreement or addendum can read the document.
+
+1. In the future, we may allow office admins to amend agreements by adding addendums
+on behalf of a signer.
+
+If this happens, we will need to update the canAmendAgreements to check to see if
+the signer is authorized in the parent CLA as an admin.
+
+TODO: get() doesn't appear to work in a function. If that changes in the future,
+we might reconsider refactoring.
+
+2. We may also allow users that are named in corporate agreements
+to read, but not amend, the CLA that they are named on.
+
+If this happens, we will need up update the read functions above.
+
+*/


### PR DESCRIPTION
- Only authenticated user can create CLAs and addendums for themselves
- Users can only read CLAs and addendums that they have signed

TODO: still requires unit tests

closes #49 