### PR TITLE
#27 - Add the scheduled function to backup firestore

### DIFF
--- a/functions/index.js
+++ b/functions/index.js
@@ -3,6 +3,7 @@ const functions = require('firebase-functions')
 const Github = require('./lib/github')
 const Gerrit = require('./lib/gerrit')
 const Cla = require('./lib/cla')
+const Backup = require('./lib/backup.js')
 const _ = require('lodash')
 
 admin.initializeApp(functions.config().firebase)
@@ -15,6 +16,11 @@ const github = new Github(
   functions.config().github.secret,
   db)
 const gerrit = new Gerrit(db)
+
+const backup = new Backup(
+  functions.config().backup.bucket_name,
+  functions.config().backup.period
+)
 
 /**
  * Handles the given event snapshot. The implementation is expected to update
@@ -100,3 +106,5 @@ exports.handleWhitelistUpdate = functions.firestore
           })
       })).catch(console.error)
   })
+
+exports.scheduledFirestoreExport = backup

--- a/functions/lib/backup.js
+++ b/functions/lib/backup.js
@@ -1,0 +1,32 @@
+const functions = require('firebase-functions')
+const firestore = require('@google-cloud/firestore')
+const client = new firestore.v1.FirestoreAdminClient()
+
+module.exports = Backup
+
+/**
+ * Firestore backup related functions
+ * @param bucket_name, schedule period
+ */
+function Backup (bucketName, period) {
+  return functions.pubsub.schedule(period).onRun((context) => {
+    const projectId = process.env.GCP_PROJECT || process.env.GCLOUD_PROJECT
+    const databaseName = client.databasePath(projectId, '(default)')
+    const bucket = 'gs://' + bucketName
+
+    return client.exportDocuments({
+      name: databaseName,
+      outputUriPrefix: bucket,
+      collectionIds: []
+    })
+      .then(responses => {
+        const response = responses[0]
+        console.log(`Operation Name: ${response.name}`)
+        return response
+      })
+      .catch(err => {
+        console.error(err)
+        throw new Error('Export operation failed')
+      })
+  })
+}


### PR DESCRIPTION
- Create a schedule function to backup the firestore to Google Storage.
- Two options should be configured before running
  - bucket_name
  - scheduled period

This patch only implemented the `MVP` goal, will send other patches for `nice to have` parts


For example:
```bash
╰─$ firebase --project ${PROJECT} functions:config:get backup
{
  "bucket_name": "clam-firestore",
  "period": "every 24 hours"
}
```