### PR TITLE
Fixes discovered during deployment of gerrit hook

### DIFF
--- a/gerrit/README.md
+++ b/gerrit/README.md
@@ -1,6 +1,7 @@
 # Gerrit integration for CLA Manager
 
-The `ref-update` script runs as a gerrit hooks:
+The `gerrit-hook` script runs as a synchronous gerrit hook, and is renamed to
+`commit-received` or `ref-update`:
 
 https://gerrit.googlesource.com/plugins/hooks/+/master/src/main/resources/Documentation/hooks.md
 
@@ -19,33 +20,39 @@ Gerrit will send to the user.
 It also handles common error cases (can't contact server, invalid response,
 etc.)
 
-## Deploying the ref-update script
+## Deploying the gerrit-hook script
 
-1. Modify the `CLA_MANAGER_URL` near the top of the `ref-updated` file to match
+1. Modify the `CLA_MANAGER_URL` near the top of the `gerrit-hook` file to match
    your cla-manager deployment.
 
 2. Test that settings are correct by running the command:
 
-        ./ref-update --uploader "Foo Bar (foo@bar.com)" --debug
+        ./gerrit-hook --uploader "Foo Bar <foo@bar.com>" --debug
 
    Test with email addresses that pass (has signed) and fail (hasn't signed)
    cases, checking the exit code (`echo $?`) after each command.
 
-3. Change `ENFORCING` to `False` in the `ref-updated` file - this makes the
-   script always exit with success.
+3. Change `ENFORCING` to `False` in the hook script - this makes the script
+   always exit with success.
 
 4. Copy to your gerrit instance (default location is in the `$site_path/hooks`
-   directory), and modify the gerrit configuration to use it, if needed:
+   directory), and change the name of the file to be `commit-received` (or
+   other names, see the gerrit hook docs).
+
+   You may also need to modify the gerrit configuration to use it, if needed:
    https://gerrit.googlesource.com/plugins/hooks/+/master/src/main/resources/Documentation/config.md
 
-5. Create and submit a few tests commits, checking with users that have both
+   You can enable additional logging of hooks by changing the log level:
+   `ssh -p 29418 user@gerrit.example gerrit logging set-level DEBUG com.googlesource.gerrit.plugins.hooks`
+
+5. Create and submit a few test commits, checking with users that have both
    signed and not signed the CLA using cla-manager.  Check that it:
 
    a. Doesn't send a message when user has signed a CLA
 
    b. Sends a message when the CLA hasn't been signed
 
-6. Change `ENFORCING` to `True` in the `ref-updated` file.
+6. Change `ENFORCING` to `True` in the hook script.
 
 ## Development and Testing
 

--- a/gerrit/gerrit-hook
+++ b/gerrit/gerrit-hook
@@ -15,7 +15,7 @@
 # limitations under the License.
 
 
-# Gerrit ref-update hook for cla-manager
+# Gerrit hook for cla-manager
 #
 # Gerrit Hook Documentation:
 # https://gerrit.googlesource.com/plugins/hooks/+/master/src/main/resources/Documentation/hooks.md
@@ -23,9 +23,9 @@
 from __future__ import absolute_import
 
 import argparse
+import email.utils
 import json
 import logging
-import re
 import sys
 import urllib.request
 
@@ -37,7 +37,7 @@ ENFORCING = True
 
 # create shared logger
 logging.basicConfig()
-logger = logging.getLogger('ref-update')
+logger = logging.getLogger('gerrit-hook')
 
 
 def parse_gerrit_args():
@@ -49,6 +49,7 @@ def parse_gerrit_args():
         --uploader-username <username>
         --oldrev <sha1>
         --newrev <sha1>
+        --cmdref <refname>
 
     Arguments added for manual testing:
         --debug
@@ -56,6 +57,7 @@ def parse_gerrit_args():
 
     parser = argparse.ArgumentParser(description="Gerrit hook for cla-manager project")
 
+    # gerrit args
     parser.add_argument("--project", help="Gerrit project")
     parser.add_argument("--refname", help="Gerrit reference name")
     parser.add_argument("--uploader", help="Uploader name and email address",
@@ -63,6 +65,9 @@ def parse_gerrit_args():
     parser.add_argument("--uploader-username", help="Uploader username")
     parser.add_argument("--oldrev", help="Hash of the parent commit")
     parser.add_argument("--newrev", help="Hash of the new commit")
+    parser.add_argument("--cmdref", help="Git ref of the new commit")
+
+    # testing args
     parser.add_argument("--debug", help="Print additional debugging information",
                         action="store_true")
 
@@ -73,17 +78,10 @@ def uploader_email(uploader):
     '''
     Given the uploader string from Gerrit, return an email address
     '''
-    # python stdlib email.utils.parseaddr doesn't support this format
 
-    if re.fullmatch(r'^[\w ]+\([^@]+@[^@]+\.[^@]+\)$', uploader):
-        # email is in the form: "Foo Bar (foo@bar.baz)"
-        (name, after) = uploader.split("(", 1)
-        (addr, extra) = after.split(")", 1)
+    (name, addr) = email.utils.parseaddr(uploader)
 
-    elif re.fullmatch(r'^[^@]+@[^@]+\.[^@]+$', uploader):
-        # email is  the bare address: "foo@bar.baz"
-        addr = uploader
-    else:
+    if '@' not in addr:
         output_status(False, "Problem with email address: '%s'" % uploader)
 
     logger.debug("Email address: '%s'", addr)

--- a/gerrit/tox.ini
+++ b/gerrit/tox.ini
@@ -25,8 +25,8 @@ deps =
   coverage
 
 commands=
-  flake8 ref-update test_ref_update.py
-  pylint --py3k ref-update test_ref_update.py
+  flake8 gerrit-hook test_hook.py
+  pylint --py3k gerrit-hook test_ref_update.py
   coverage run -m unittest
   coverage report -m
 


### PR DESCRIPTION
- Use a generic name for the script in the repo, as it could be
  deployed using different names.
- Use the python built-in email parser, which is compatible (contrary to
  Gerrit docs)
- More documentation