### PR TITLE
Implement Ain's feedback

### DIFF
--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<project version="4">
-  <component name="VcsDirectoryMappings">
-    <mapping directory="" vcs="Git" />
-  </component>
-</project>

--- a/client/src/js/Home.jsx
+++ b/client/src/js/Home.jsx
@@ -79,7 +79,7 @@ export default class Home extends React.Component {
           name: cla.data().signer.name,
           date,
           displayDate: date.toLocaleDateString('default', dateOptions),
-          link: <Link href={linkUrl}><Button variant='outlined' color='primary'>View Agreement</Button></Link>
+          link: <Link href={linkUrl}><Button variant='outlined' color='primary'>View/Edit</Button></Link>
         }
 
         if (type === AgreementType.INDIVIDUAL) {
@@ -122,7 +122,7 @@ export default class Home extends React.Component {
             <AgreementsTable
               header='Individual Agreements'
               description='Individual agreements we have on file for you:'
-              columnTitles={['Name', 'Date Signed', 'Manage']}
+              columnTitles={['Signatory', 'Date Signed', 'Actions']}
               columnIds={['name', 'displayDate', 'link']}
               data={this.state.individualCLATable}
             />
@@ -131,7 +131,7 @@ export default class Home extends React.Component {
             <AgreementsTable
               header='Institutional Agreements'
               description='Institutional agreements we have on file for you:'
-              columnTitles={['Organization', 'Signer', 'Date Signed', 'View / Manage']}
+              columnTitles={['Organization', 'Signatory', 'Date Signed', 'Actions']}
               columnIds={['organization', 'name', 'displayDate', 'link']}
               data={this.state.institutionCLATable}
             />

--- a/client/src/js/SignIn.jsx
+++ b/client/src/js/SignIn.jsx
@@ -3,8 +3,8 @@ import React, { useState } from 'react'
 import { FirebaseApp } from '../common/app/app'
 
 import { makeStyles } from '@material-ui/core/styles'
-import { TextField, Grid, Button, Container, Box } from '@material-ui/core'
-import { Alert } from '@material-ui/lab';
+import { Box, Button, Container, Grid, TextField } from '@material-ui/core'
+import { Alert } from '@material-ui/lab'
 import SendIcon from '@material-ui/icons/Send'
 
 const useStyles = makeStyles(theme => ({
@@ -89,6 +89,21 @@ export default function SignIn () {
           </Box>
         </Grid>
         <Grid item xs={12}>
+          <p>
+            A Contributor License Agreement (CLA) is a legal document in which a
+            contributor (like you) states that they are entitled to contribute
+            to a project, and that they are willing to have their contribution
+            used in distributions and derivative works. You will need to
+            electronically sign a CLA before ONF can accept any contribution
+            from you or your company.
+          </p>
+          <p>
+            <strong>
+              Please enter your email address and click the button below. You
+              will receive a link to access a portal where you will be able to
+              sign a new CLA or view/edit existing ones.
+            </strong>
+          </p>
           <form
             onSubmit={(e) => e.preventDefault()}
             noValidate
@@ -105,11 +120,13 @@ export default function SignIn () {
               autoFocus
             />
             <p>
-              If you are already registered, please enter the email address you used to register with the ONF CLA Portal.
-              Click the button to receive a link to view your ONF CLA information.
-              <br/><br/>
-              If you have not yet registered, please enter the email address you wish to use to register with the ONF CLA Portal.
-              Click the button to receive a link to complete the registration process.
+              <strong>IMPORTANT:</strong> if want to sign an agreement for your
+              company (Institutional CLA), please enter your work email address.
+            </p>
+            <p>
+              If you have already signed a CLA through this portal, please enter
+              the email address you used to sign to view your existing CLA
+              information.
             </p>
             <Button
               className={classes.button}
@@ -119,7 +136,7 @@ export default function SignIn () {
               onClick={signIn}
               endIcon={<SendIcon/>}
             >
-              Send Sign In Link
+              Send Access Link
             </Button>
           </form>
         </Grid>

--- a/client/src/js/addendum/AddendumContainer.jsx
+++ b/client/src/js/addendum/AddendumContainer.jsx
@@ -1,30 +1,30 @@
-import React, { useState, useEffect } from 'react'
+import React, { useEffect, useState } from 'react'
 import PropTypes from 'prop-types'
 import { makeStyles } from '@material-ui/core/styles'
 import { Addendum, AddendumType } from '../../common/model/addendum'
 import {
-  Card,
-  Grid,
-  Button,
   Box,
+  Button,
+  Card,
   Dialog,
   DialogActions,
   DialogContent,
   DialogContentText,
-  DialogTitle
+  DialogTitle,
+  Grid
 } from '@material-ui/core'
 import { Agreement } from '../../common/model/agreement'
 import UserForm from '../user/UserForm'
 import IdentityCard from './IdentityCard'
 import * as _ from 'lodash'
 import KeyboardBackspaceIcon from '@material-ui/icons/KeyboardBackspace'
-import { useHistory, Link } from 'react-router-dom'
+import { Link, useHistory } from 'react-router-dom'
 
 const useStyles = makeStyles(theme => ({
   root: {
     padding: theme.spacing(2),
     marginTop: theme.spacing(2)
-  },
+  }
 }))
 
 /**
@@ -143,8 +143,9 @@ function AddendumContainer (props) {
   return (
     <Grid container spacing={2}>
       <Grid item xs={12}>
-        <h2>Active identities for this agreement:</h2>
-        <Box>here is a list of identities that are authorized to contribute code under this agreement</Box>
+        <h2>Active Identities for this Agreement</h2>
+        <Box>Here is a list of identities that are authorized to contribute code
+          under this agreement: {activeIdentities.length === 0 ? 'EMPTY' : ''}</Box>
         <Grid container spacing={2}>
           {activeIdentities.map((a, i) =>
             <Grid key={`container-${i}`} item xs={12} sm={12} md={6} lg={4}>
@@ -156,11 +157,15 @@ function AddendumContainer (props) {
       <Grid item xs={12}>
         <Grid container spacing={2}>
           <Grid item xs={12}>
+            <h2>Update Agreement</h2>
             <Box>
-              <h2>Update Agreement:</h2>
-              You can modify the people allowed to contribute code under this agreement by adding or removing them from
-              it. <br/>
-              Make sure to click on &quot;Sign Addendum&quot; below
+              <p>
+                You can modify the people allowed to contribute under this
+                agreement by adding or removing them from it.
+              </p>
+              <p>
+                Make sure to click on &quot;Sign Addendum&quot; below.
+              </p>
             </Box>
           </Grid>
           {removedIdentities.map((a, i) =>

--- a/client/src/js/agreement/AgreementContainer.jsx
+++ b/client/src/js/agreement/AgreementContainer.jsx
@@ -6,12 +6,18 @@ import { TextValidator, ValidatorForm } from 'react-material-ui-form-validator'
 import Button from '@material-ui/core/Button'
 import AgreementDisplay from './AgreementDisplay'
 import AddendumContainer from '../addendum/AddendumContainer'
-import { FirebaseApp } from '../../common/app/app'
 import { Agreement, AgreementType } from '../../common/model/agreement'
 import { Alert, Skeleton } from '@material-ui/lab'
 import { useHistory } from 'react-router-dom'
 import { Identity, IdentityType } from '../../common/model/identity'
 import { ClaTextCorporate, ClaTextIndividual } from '../cla/ClaText'
+import List from '@material-ui/core/List'
+import ListItem from '@material-ui/core/ListItem'
+import ListItemAvatar from '@material-ui/core/ListItemAvatar'
+import ListItemText from '@material-ui/core/ListItemText'
+import Avatar from '@material-ui/core/Avatar'
+import ReceiptIcon from '@material-ui/icons/Receipt'
+import TextField from '@material-ui/core/TextField'
 
 const useStyles = makeStyles(theme => ({
   root: {
@@ -36,11 +42,12 @@ function AgreementContainer (props) {
 
   // component state
   const [error, setError] = useState(null)
-  const [agreement, setAgreement] = useState({})
+  const [agreement, setAgreement] = useState({ body: '' })
   const [loader, setLoading] = useState(agreementId !== undefined)
 
   // form values
-  const [name, setName] = useState('')
+  const [signerName, setName] = useState('')
+  const [signerEmail, setSignerEmail] = useState(props.user.email)
   const [orgName, setOrgName] = useState('')
   const [phoneNumber, setPhoneNumber] = useState('')
   const [signerTitle, setSignerTitle] = useState('')
@@ -52,80 +59,39 @@ function AgreementContainer (props) {
       Agreement.get(props.agreementId)
         .then(res => {
           setAgreement(res)
+          setName(res.signer.name)
+          setSignerEmail(res.signer.value)
+          if (res.type === AgreementType.CORPORATE) {
+            setOrgName(res.organization)
+            setOrgAddress(res.organizationAddress)
+            setSignerTitle(res.signer.title)
+            setPhoneNumber(res.signer.phoneNumber)
+          }
           setLoading(false)
         })
         .catch(console.error)
     } else {
-      // set a default text
       if (props.agreementType === AgreementType.CORPORATE) {
-        setAgreement({ body: ClaTextCorporate })
+        setAgreement({
+          type: AgreementType.CORPORATE,
+          body: ClaTextCorporate
+        })
       } else if (props.agreementType === AgreementType.INDIVIDUAL) {
-        setAgreement({ body: ClaTextIndividual })
+        setAgreement({
+          type: AgreementType.INDIVIDUAL,
+          body: ClaTextIndividual
+        })
       }
     }
   }, [props.agreementType, props.agreementId])
-
-  let organizationTextValidator = null
-
-  if (props.agreementType === AgreementType.CORPORATE) {
-    organizationTextValidator = (
-      <div>
-        <TextValidator
-          fullWidth
-          label='Phone Number'
-          name='phoneNumber'
-          value={phoneNumber}
-          onChange={e => setPhoneNumber(e.target.value)}
-          validators={['required', 'matchRegexp:^[0-9]+$']}
-          errorMessages={['You must enter the company phone number', 'Please enter numbers only']}
-          variant='outlined'
-          className={classes.formField}
-        />
-        <TextValidator
-          fullWidth
-          label='Title'
-          name='signerTitle'
-          value={signerTitle}
-          onChange={e => setSignerTitle(e.target.value)}
-          validators={['required']}
-          errorMessages={['You must enter the company title']}
-          variant='outlined'
-          className={classes.formField}
-        />
-        <TextValidator
-          fullWidth
-          label='Organization Name'
-          name='orgName'
-          value={orgName}
-          onChange={e => setOrgName(e.target.value)}
-          validators={['required']}
-          errorMessages={['You must enter the company name']}
-          variant='outlined'
-          className={classes.formField}
-        />
-        <TextValidator
-          fullWidth
-          label='Organization Address'
-          name='orgAddress'
-          value={orgAddress}
-          onChange={e => setOrgAddress(e.target.value)}
-          validators={['required']}
-          errorMessages={['You must enter the company address']}
-          variant='outlined'
-          className={classes.formField}
-        />
-
-      </div>
-    )
-  }
 
   const handleSubmit = (evt) => {
     evt.preventDefault()
 
     const signer = new Identity(
       IdentityType.EMAIL,
-      name,
-      FirebaseApp.auth().currentUser.email
+      signerName,
+      signerEmail
     )
 
     signer.title = signerTitle
@@ -162,30 +128,128 @@ function AgreementContainer (props) {
       })
   }
 
+  const ifCorporate = (value, otherwise) => {
+    return agreement.type === AgreementType.CORPORATE ? value : otherwise
+  }
+
+  const ifSigned = (value = true, otherwise = false) => {
+    return agreement.id ? value : otherwise
+  }
+
   // NOTE consider moving in a different component
   const form = (
-    <ValidatorForm onSubmit={handleSubmit}>
+    <ValidatorForm
+      onSubmit={ifSigned(() => {}, handleSubmit)}
+      onError={errors => console.log(errors)}>
       <Grid container spacing={2}>
         <Grid item xs={12}>
           {error ? <Alert severity='error'>{error}</Alert> : null}
         </Grid>
-        <Grid item xs={12} md={10}>
+        <Grid item xs={12}>
+          <Box component='div' display={ifSigned('', 'none')}>
+            <TextField
+              fullWidth
+              InputProps={{
+                readOnly: true
+              }}
+              label='Date Signed'
+              name='dateSigned'
+              value={agreement.dateSigned}
+              variant='outlined'
+              className={classes.formField}
+            />
+          </Box>
           <TextValidator
             fullWidth
-            label='Full Name'
-            name='name'
-            value={name}
+            InputProps={{
+              readOnly: ifSigned()
+            }}
+            label='Signer Full Name'
+            name='signerName'
+            value={signerName}
             onChange={e => setName(e.target.value)}
             validators={['required']}
-            errorMessages={['You must enter your name']}
+            errorMessages={['You must enter your full name']}
             variant='outlined'
             className={classes.formField}
           />
-          {organizationTextValidator}
-        </Grid>
-        <Grid item xs={12} md={2}>
-          <Box textAlign='right' m={1}>
+          <TextValidator
+            fullWidth
+            InputProps={{
+              readOnly: true
+            }}
+            label='Signer Email Address'
+            name='signerEmail'
+            value={signerEmail}
+            validators={['required']}
+            errorMessages={['You must enter your email address']}
+            variant='outlined'
+            className={classes.formField}
+          />
+          <Box
+            component='div'
+            display={ifCorporate('', 'none')}
+          >
+            <TextValidator
+              fullWidth
+              InputProps={{
+                readOnly: ifSigned()
+              }}
+              label='Signer Title'
+              name='signerTitle'
+              value={signerTitle}
+              onChange={e => setSignerTitle(e.target.value)}
+              validators={ifCorporate(['required'], [])}
+              errorMessages={['You must enter your title']}
+              variant='outlined'
+              className={classes.formField}
+            />
+            <TextValidator
+              fullWidth
+              InputProps={{
+                readOnly: ifSigned()
+              }}
+              label='Signer Phone Number'
+              name='phoneNumber'
+              value={phoneNumber}
+              onChange={e => setPhoneNumber(e.target.value)}
+              validators={ifCorporate(['required'], [])}
+              errorMessages={['You must enter your phone number']}
+              variant='outlined'
+              className={classes.formField}
+            />
+            <TextValidator
+              fullWidth
+              InputProps={{
+                readOnly: ifSigned()
+              }}
+              label='Organization Name'
+              name='orgName'
+              value={orgName}
+              onChange={e => setOrgName(e.target.value)}
+              validators={ifCorporate(['required'], [])}
+              errorMessages={['You must enter the company name']}
+              variant='outlined'
+              className={classes.formField}
+            />
+            <TextValidator
+              fullWidth
+              InputProps={{
+                readOnly: ifSigned()
+              }}
+              label='Organization Address'
+              name='orgAddress'
+              value={orgAddress}
+              onChange={e => setOrgAddress(e.target.value)}
+              validators={ifCorporate(['required'], [])}
+              errorMessages={['You must enter the company address']}
+              variant='outlined'
+              className={classes.formField}
+            />
+          </Box>
+          <Box component='div' display={ifSigned('none', '')}>
             <Button
+              fullWidth
               type='submit'
               variant='contained'
               color='primary'
@@ -195,27 +259,39 @@ function AgreementContainer (props) {
           </Box>
         </Grid>
       </Grid>
-
     </ValidatorForm>)
+
+  const agreementHeader = (
+    <List className={classes.root}>
+      <ListItem>
+        <ListItemAvatar>
+          <Avatar>
+            <ReceiptIcon/>
+          </Avatar>
+        </ListItemAvatar>
+        <ListItemText primary="Agreement ID" secondary={agreement.id}/>
+      </ListItem>
+    </List>
+  )
 
   return (
     <div>
-      {loader ?
-        <Paper elevation={23} className={classes.root}>
+      {loader
+        ? <Paper elevation={23} className={classes.root}>
           <Skeleton className={classes.skeleton} variant='text'/>
           <Skeleton className={classes.skeleton} variant='text'/>
           <Skeleton className={classes.skeleton} variant='circle' width={40} height={40}/>
           <Skeleton className={classes.skeleton} variant='text'/>
           <Skeleton className={classes.skeleton} variant='rect' width={'100%'} height={118}/>
         </Paper>
-        :
-        <Paper elevation={23} className={classes.root}>
+        : <Paper elevation={23} className={classes.root}>
           <Grid container spacing={2}>
+            {ifSigned(agreementHeader, null)}
             <Grid item xs={12}>
               <AgreementDisplay text={agreement.body}/>
             </Grid>
           </Grid>
-          {agreementId ? null : form}
+          {form}
           {agreementId ? <AddendumContainer user={props.user} agreementId={agreementId}/> : null}
         </Paper>
       }

--- a/client/src/js/agreement/CreateAgreementContainer.jsx
+++ b/client/src/js/agreement/CreateAgreementContainer.jsx
@@ -15,6 +15,9 @@ const useStyles = makeStyles(theme => ({
   },
   cell: {
     textAlign: 'center'
+  },
+  textCenter: {
+    textAlign: 'center'
   }
 }))
 
@@ -26,19 +29,19 @@ function CreateAgreementContainer () {
   return (
     <Paper elevation={23} className={classes.root}>
       <h2 className={classes.h2}>Sign a CLA</h2>
-      <p>Who will you be submitting contributions on behalf of?</p>
+      <p className={classes.textCenter}>Who will you be submitting contributions on behalf of?</p>
       <Grid container spacing={3} justify='center'>
         <Grid item xs={12} md={6} className={classes.cell}>
           <Link to={`/sign/${AgreementType.INDIVIDUAL}`}>
             <Button variant='contained' color='primary' size='large'>
-              Only Yourself / Sign Individual CLA
+              Only Yourself &rarr; Sign Individual CLA
             </Button>
           </Link>
         </Grid>
         <Grid item xs={12} md={6} className={classes.cell}>
           <Link to={`/sign/${AgreementType.CORPORATE}`}>
             <Button variant='contained' color='primary' size='large'>
-              Your Employer / Sign Corporate CLA
+              Your Employer &rarr; Sign Institutional CLA
             </Button>
           </Link>
         </Grid>

--- a/client/src/js/cla/ClaText.js
+++ b/client/src/js/cla/ClaText.js
@@ -3,176 +3,211 @@ export const ClaTextIndividual =
 ## Individual Contributor License Agreement (“Agreement”)
 
 Thank you for your interest in Open Networking Foundation (“ONF”). In order to
-clarify the intellectual property licensed granted with Contributions from any person or entity,
-each Contributor must agree to the terms of a Contributor License Agreement (“CLA”). This
-license is for your protection as a Contributor as well as the protection of ONF and its users; it
-does not change your rights to use your own Contributions for any other purpose.
-You accept and agree to the following terms and conditions for Your present and future
-Contributions submitted to ONF. Except for the license granted herein to ONF and recipients of
-the Work (as defined below) distributed by ONF, You reserve all right, title, and interest in and
-to Your Contributions.
+clarify the intellectual property license granted with Contributions from any
+person or entity, each Contributor must agree to the terms of a Contributor
+License Agreement (“CLA”). This license is for your protection as a Contributor
+as well as the protection of ONF and its users; it does not change your rights
+to use your own Contributions for any other purpose. You accept and agree to the
+following terms and conditions for Your present and future Contributions
+submitted to ONF. Except for the license granted herein to ONF and recipients of
+the Work (as defined below) distributed by ONF, You reserve all right, title,
+and interest in and to Your Contributions.
 
-1. Definitions.
-“You” (or “Your”) shall mean the copyright owner or legal entity authorized by the
-copyright owner that is making this Agreement with ONF. For legal entities, the entity making a
-Contribution and all other entities that control, are controlled by, or are under common control
-with that entity are considered to be a single “Contributor.” For the purposes of this definition,
-“control” means (i) the power, direct or indirect, to cause the direction or management of such
-entity, whether by contract or otherwise, or (ii) ownership of fifty percent (50%) or more of the
-outstanding shares, or (iii) beneficial ownership of such entity.
-“Contribution” shall mean the code, documentation, use cases, or other works of
-authorship, including any modifications or additions to an existing work, that are intentionally
-submitted by You to ONF for inclusion in, or documentation of, any open source software
-projects established, owned, or managed by ONF (the “Work”). For the purposes of this
-definition, “submitted” means any form of electronic, verbal, or written communication sent to
-ONF or its representatives, including but not limited to communication on electronic mailing
-lists, source code control systems, and issue tracking systems that are managed by, or on behalf
-of, ONF for the purpose of discussing and improving the Work, but excluding communication
-that is conspicuously marked or otherwise designated in writing by You as “Not a Contribution.”
+1. Definitions. “You” (or “Your”) shall mean the copyright owner or legal entity
+authorized by the copyright owner that is making this Agreement with ONF. For
+legal entities, the entity making a Contribution and all other entities that
+control, are controlled by, or are under common control with that entity are
+considered to be a single “Contributor.” For the purposes of this definition,
+“control” means (i) the power, direct or indirect, to cause the direction or
+management of such entity, whether by contract or otherwise, or (ii) ownership
+of fifty percent (50%) or more of the outstanding shares, or (iii) beneficial
+ownership of such entity. “Contribution” shall mean the code, documentation, use
+cases, or other works of authorship, including any modifications or additions to
+an existing work, that are intentionally submitted by You to ONF for inclusion
+in, or documentation of, any open source software projects established, owned,
+or managed by ONF (the “Work”). For the purposes of this definition, “submitted”
+means any form of electronic, verbal, or written communication sent to ONF or
+its representatives, including but not limited to communication on electronic
+mailing lists, source code control systems, and issue tracking systems that are
+managed by, or on behalf of, ONF for the purpose of discussing and improving the
+Work, but excluding communication that is conspicuously marked or otherwise
+designated in writing by You as “Not a Contribution.”
 
 2. Grant of Copyright License. Subject to the terms and conditions of this
-Agreement, You hereby grant to ONF and to recipients of software distributed by ONF a
-perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable copyright license to
-reproduce, prepare derivative works of, publicly display, publicly perform, sublicense, and
-distribute Your Contributions and such derivative works.    
+Agreement, You hereby grant to ONF and to recipients of software distributed by
+ONF a perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+copyright license to reproduce, prepare derivative works of, publicly display,
+publicly perform, sublicense, and distribute Your Contributions and such
+derivative works.
 
-3. Grant of Patent License. Subject to the terms and conditions of this Agreement, You
-hereby grant to ONF and to recipients of software distributed by ONF a perpetual, worldwide,
-non- exclusive, no-charge, royalty-free, irrevocable (except as stated in this section) patent
-license to make, have made, use, offer to sell, sell, import, and otherwise transfer the Work,
-where such license applies only to those patent claims licensable by You that are necessarily
-infringed by Your Contribution(s) alone or by combination of Your Contribution(s) with the
-Work to which such Contribution(s) were submitted. If any entity institutes patent litigation
-against You or any other entity (including a cross- claim or counterclaim in a lawsuit) alleging
-that Your Contribution, or the Work to which You have contributed, constitutes direct or
-contributory patent infringement, then any patent licenses granted to that entity under this
-Agreement for that Contribution or Work shall terminate as of the date such litigation is filed.
+3. Grant of Patent License. Subject to the terms and conditions of this
+Agreement, You hereby grant to ONF and to recipients of software distributed by
+ONF a perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+(except as stated in this section) patent license to make, have made, use, offer
+to sell, sell, import, and otherwise transfer the Work, where such license
+applies only to those patent claims licensable by You that are necessarily
+infringed by Your Contribution(s) alone or by combination of Your
+Contribution(s) with the Work to which such Contribution(s) were submitted. If
+any entity institutes patent litigation against You or any other entity
+(including a cross-claim or counterclaim in a lawsuit) alleging that Your
+Contribution, or the Work to which You have contributed, constitutes direct or
+contributory patent infringement, then any patent licenses granted to that
+entity under this Agreement for that Contribution or Work shall terminate as of
+the date such litigation is filed.
 
-4. Right to Grant Licenses. You represent that You are legally entitled to grant the
-above licenses. If your employer(s) has (have) rights to intellectual property that you create that
-includes your Contributions, you represent that you have received permission to make
-Contributions on behalf of that employer, that your employer has waived such rights for your
-Contributions to ONF, or that your employer has executed a separate Corporate CLA with ONF.
+4. Right to Grant Licenses. You represent that You are legally entitled to grant
+the above licenses. If your employer(s) has (have) rights to intellectual
+property that you create that includes your Contributions, you represent that
+you have received permission to make Contributions on behalf of that employer,
+that your employer has waived such rights for your Contributions to ONF, or that
+your employer has executed a separate Corporate CLA with ONF.
 
-5. Original Creation. You represent that each of Your Contributions is Your original
-creation (see section 7 for submissions on behalf of others). You represent that Your Contribution
-submissions include complete details of any third-party license or other restriction (including,
-but not limited to, related patents and trademarks) of which you are personally aware and which
-are associated with any part of Your Contributions.
+5. Original Creation. You represent that each of Your Contributions is Your
+original creation (see section 7 for submissions on behalf of others). You
+represent that Your Contribution submissions include complete details of any
+third-party license or other restriction (including, but not limited to, related
+patents and trademarks) of which you are personally aware and which are
+associated with any part of Your Contributions.
 
-6. Support; Warranty Disclaimer. You are not expected to provide support for Your
-Contributions, except to the extent You desire to provide support. You may provide support for
-free, for a fee, or not at all. Unless required by applicable law or agreed to in writing, You
-provide Your Contributions on an “AS IS” BASIS, WITHOUT WARRANTIES OR
-CONDITIONS OF ANY KIND, either express or implied, including, without limitation, any
-warranties or conditions of TITLE, NON- INFRINGEMENT, MERCHANTABILITY, or
-FITNESS FOR A PARTICULAR PURPOSE.
+6. Support; Warranty Disclaimer. You are not expected to provide support for
+Your Contributions, except to the extent You desire to provide support. You may
+provide support for free, for a fee, or not at all. Unless required by
+applicable law or agreed to in writing, You provide Your Contributions on an “AS
+IS” BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+implied, including, without limitation, any warranties or conditions of TITLE,
+NON- INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A PARTICULAR PURPOSE.
 
 7. Contributions That Are Not Your Original Creation. Should You wish to submit
-work that is not Your original creation, You may submit it to ONF separately from any
-Contribution, identifying the complete details of its source and of any license or other restriction
-(including, but not limited to, related patents, trademarks, and license agreements) of which you
-are personally aware, and conspicuously marking the work as “Submitted on behalf of a third-
-party: &#91;named here&#93;”.
+work that is not Your original creation, You may submit it to ONF separately
+from any Contribution, identifying the complete details of its source and of any
+license or other restriction (including, but not limited to, related patents,
+trademarks, and license agreements) of which you are personally aware, and
+conspicuously marking the work as “Submitted on behalf of a third- party:
+&#91;named here&#93;”.
 
 8. Required Notifications. You agree to notify ONF of any facts or circumstances
-of which you become aware that would make these representations inaccurate in any respect.
-`
+of which you become aware that would make these representations inaccurate in
+any respect.`
 
 export const ClaTextCorporate =
 `# Open Networking Foundation
 ## Institutional Contributor License Agreement ("Agreement")
 
+Thank you for your interest in the Open Networking Foundation (“ONF”). In order
+to clarify the intellectual property license granted with Contributions from any
+person or entity, ONF must have a Contributor License Agreement (“CLA”) on file
+that has been signed by each Contributor, indicating agreement to the license
+terms below. This license is for your protection as a Contributor as well as the
+protection of ONF and its users; it does not change your rights to use your own
+Contributions for any other purpose.
 
-Thank you for your interest in the Open Networking Foundation (“ONF”).  In order to clarify the intellectual property 
-license granted with Contributions from any person or entity, ONF must have a Contributor License Agreement (“CLA”) on 
-file that has been signed by each Contributor, indicating agreement to the license terms below. This license is for your
-protection as a Contributor as well as the protection of ONF and its users; it does not change your rights to use your 
-own Contributions for any other purpose.
+This version of the Agreement allows an entity (the "Institution") to submit
+Contributions to ONF, to authorize Contributions submitted by its designated
+employees to ONF, and to grant copyright and patent licenses thereto.
 
-This version of the Agreement allows an entity (the "Institution") to submit Contributions to ONF, to authorize 
-Contributions submitted by its designated employees to ONF, and to grant copyright and patent licenses thereto.
+You accept and agree to the following terms and conditions for Your
+Contributions submitted to ONF. Except for the license granted herein to ONF and
+recipients of software distributed by ONF, You reserve all right, title, and
+interest in and to Your Contributions.
 
-You accept and agree to the following terms and conditions for Your Contributions submitted to ONF. Except for the 
-license granted herein to ONF and recipients of software distributed by ONF, You reserve all right, title, and interest 
-in and to Your Contributions.
+1. Definitions. "You" (or "Your") shall mean the Institution that is making this
+Agreement with ONF, which must be the copyright owner of the Contribution(s) or
+be authorized by the copyright owner to make the Contribution(s) under this
+Agreement. The Institution and all other entities that control, are controlled
+by, or are under common control with the Institution are considered to be a
+single “Contributor.” For the purposes of this definition, "control" means (i)
+the power, direct or indirect, to cause the direction or management of such
+entity, whether by contract or otherwise, or (ii) ownership of fifty percent
+(50%) or more of the outstanding shares, or (iii) beneficial ownership of such
+entity. "Contribution" shall mean the code, documentation, use cases, or other
+works of authorship, including any modifications or additions to an existing
+work, that are intentionally submitted by You to ONF for inclusion in, or
+documentation of, any of the open source software projects established, owned,
+or managed by ONF (the "Work"). For the purposes of this definition, "submitted"
+means any form of electronic, verbal, or written communication sent to ONF or
+its representatives, including but not limited to communication on electronic
+mailing lists, source code control systems, and issue tracking systems that are
+managed by, or on behalf of, ONF for the purpose of discussing and improving the
+Work, but excluding communication that is conspicuously marked or otherwise
+designated in writing by You as "Not a Contribution."
 
-1. Definitions.
-"You" (or "Your") shall mean the Institution that is making this Agreement with ONF, which must be the copyright owner
-of the Contribution(s) or be authorized by the copyright owner to make the Contribution(s) under this Agreement.  
-The Institution and all other entities that control, are controlled by, or are under common control with the Institution
-are considered to be a single “Contributor.”  For the purposes of this definition, "control" means (i) the power, direct
-or indirect, to cause the direction or management of such entity, whether by contract or otherwise, or (ii) ownership 
-of fifty percent (50%) or more of the outstanding shares, or (iii) beneficial ownership of such entity.
-"Contribution" shall mean the code, documentation, use cases, or other works of authorship, including any modifications 
-or additions to an existing work, that are intentionally submitted by You to ONF for inclusion in, or documentation of,
-any of the open source software projects established, owned, or managed by ONF (the "Work"). For the purposes of this
-definition, "submitted" means any form of electronic, verbal, or written communication sent to ONF or its 
-representatives, including but not limited to communication on electronic mailing lists, source code control systems,
-and issue tracking systems that are managed by, or on behalf of, ONF for the purpose of discussing and improving the 
-Work, but excluding communication that is conspicuously marked or otherwise designated in writing by You as 
-"Not a Contribution."
+2. Grant of Copyright License. Subject to the terms and conditions of this
+Agreement, You hereby grant to ONF and to recipients of software distributed by
+ONF a perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+copyright license to reproduce, prepare derivative works of, publicly display,
+publicly perform, sublicense, and distribute Your Contributions and such
+derivative works.
 
-2. Grant of Copyright License. Subject to the terms and conditions of this Agreement, You hereby grant to ONF and to 
-recipients of software distributed by ONF a perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable
-copyright license to reproduce, prepare derivative works of, publicly display, publicly perform, sublicense, and 
-distribute Your Contributions and such derivative works.
+3. Grant of Patent License. Subject to the terms and conditions of this
+Agreement, You hereby grant to ONF and to recipients of software distributed by
+ONF a perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+(except as stated in this section) patent license to make, have made, use, offer
+to sell, sell, import, and otherwise transfer the Work, where such license
+applies only to those patent claims licensable by You that are necessarily
+infringed by Your Contribution(s) alone or by combination of Your
+Contribution(s) with the Work to which such Contribution(s) were submitted. If
+any entity institutes patent litigation against You or any other entity
+(including a cross-claim or counterclaim in a lawsuit) alleging that Your
+Contribution, or the Work to which You have contributed, constitutes direct or
+contributory patent infringement, then any patent licenses granted to that
+entity under this Agreement for that Contribution or Work shall terminate as of
+the date such litigation is filed.
 
-3. Grant of Patent License. Subject to the terms and conditions of this Agreement, You hereby grant to ONF and to 
-recipients of software distributed by ONF a perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable
-(except as stated in this section) patent license to make, have made, use, offer to sell, sell, import, and otherwise
-transfer the Work, where such license applies only to those patent claims licensable by You that are necessarily
-infringed by Your Contribution(s) alone or by combination of Your Contribution(s) with the Work to which such
-Contribution(s) were submitted. If any entity institutes patent litigation against You or any other entity (including
-a cross-claim or counterclaim in a lawsuit) alleging that Your Contribution, or the Work to which You have contributed,
-constitutes direct or contributory patent infringement, then any patent licenses granted to that entity under this
-Agreement for that Contribution or Work shall terminate as of the date such litigation is filed.
+4. Right to Grant Licenses. You represent that You are legally entitled to grant
+the above licenses. You represent further that each employee or other
+representative of the Institution designated on Schedule A attached hereto (as
+it may be modified from time to time) is authorized to submit Contributions on
+behalf of the Institution. You further represent that the Primary Contact and
+Alternate Contact (if any) designated above, or such successor Primary Contact
+or Alternate Contact that You designate via written notice to ONF, each have the
+power and authority to modify Schedule A by providing written notice of such
+modification to ONF. Notice of any change to Your Primary Contact, Alternate
+Contact, or Schedule A may be provided via e-mail message by Your then-current
+Primary Contact or Alternate Contact, and does not need to be in the form of a
+signed amendment to this Agreement to be binding upon the parties.
 
-4. Right to Grant Licenses. You represent that You are legally entitled to grant the above licenses. You represent 
-further that each employee or other representative of the Institution designated on Schedule A attached hereto (as it
-may be modified from time to time) is authorized to submit Contributions on behalf of the Institution.  You further
-represent that the Primary Contact and Alternate Contact (if any) designated above, or such successor Primary Contact
-or Alternate Contact that You designate via written notice to ONF, each have the power and authority to modify Schedule
-A by providing written notice of such modification to ONF.  Notice of any change to Your Primary Contact, Alternate
-Contact, or Schedule A may be provided via e-mail message by Your then-current Primary Contact or Alternate Contact,
-and does not need to be in the form of a signed amendment to this Agreement to be binding upon the parties.
+5. Original Creation. You represent that each of Your Contributions is Your
+original creation (see section 7 for submissions on behalf of others).
 
-5. Original Creation.  You represent that each of Your Contributions is Your original creation (see section 7 for
-submissions on behalf of others).
+6. Support; Warranty Disclaimer. You are not expected to provide support for
+Your Contributions, except to the extent You desire to provide support. You may
+provide support for free, for a fee, or not at all. Unless required by
+applicable law or agreed to in writing, You provide Your Contributions on an "AS
+IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+implied, including, without limitation, any warranties or conditions of TITLE,
+NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A PARTICULAR PURPOSE.
 
-6. Support; Warranty Disclaimer.  You are not expected to provide support for Your Contributions, except to the extent
-You desire to provide support. You may provide support for free, for a fee, or not at all. Unless required by applicable
-law or agreed to in writing, You provide Your Contributions on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-KIND, either express or implied, including, without limitation, any warranties or conditions of TITLE, NON-INFRINGEMENT,
-MERCHANTABILITY, or FITNESS FOR A PARTICULAR PURPOSE.
-
-7. Contributions That Are Not Your Original Creation.  Should You wish to submit work that is not Your original
-creation, You may submit it to ONF separately from any Contribution, identifying the complete details of its source and
-of any license or other restriction (including, but not limited to, related patents, trademarks, and license agreements)
-of which you are personally aware, and conspicuously marking the work as "Submitted on behalf of a third-party:
+7. Contributions That Are Not Your Original Creation. Should You wish to submit
+work that is not Your original creation, You may submit it to ONF separately
+from any Contribution, identifying the complete details of its source and of any
+license or other restriction (including, but not limited to, related patents,
+trademarks, and license agreements) of which you are personally aware, and
+conspicuously marking the work as "Submitted on behalf of a third-party:
 &#91;named here&#93;".
 
-8. Required Notifications.  It is Your responsibility to notify ONF when any change is required to the list of
-designated employees authorized to submit Contributions on behalf of the Institution, or to the Institution's Primary
+8. Required Notifications. It is Your responsibility to notify ONF when any
+change is required to the list of designated employees authorized to submit
+Contributions on behalf of the Institution, or to the Institution's Primary
 Contact or Alternate Contact.
 
-9. This Agreement Supersedes Prior Agreements.  If You have previously entered into an Institutional Contributor License
- Agreement with ONF related to any one or more open source software projects established, owned, or managed by ONF, this
- Agreement shall supersede and replace all such prior agreements.
-`
+9. This Agreement Supersedes Prior Agreements. If You have previously entered
+into an Institutional Contributor License Agreement with ONF related to any one
+or more open source software projects established, owned, or managed by ONF,
+this Agreement shall supersede and replace all such prior agreements.`
+
 export const ClaRequestCorporate =
 `Dear <boss, CTO, etc.>,
 
-I would like to contribute to one of Open Networking Foundation's projects, which requires a Contributor License
-Agreement (CLA).
+I would like to contribute to one of Open Networking Foundation's projects,
+which requires a Contributor License Agreement (CLA).
 
-If we don't have a corporate CLA on file, could you please sign one? Then, can you please add my email address and
-Github ID to our CLA?
+If we don't have an institutional CLA on file, could you please sign one? Then, can
+you please add my email address and Github ID to our CLA?
 
 https://cla.opennetworking.org/
 
 My Email used for contributions: _______
+
 My Github ID: _______
 
-Thanks!
-_______`
+Thanks!`

--- a/client/src/js/helpers/SignCheck.jsx
+++ b/client/src/js/helpers/SignCheck.jsx
@@ -21,6 +21,9 @@ const useStyles = makeStyles(theme => ({
   },
   cell: {
     textAlign: 'center'
+  },
+  textCenter: {
+    textAlign: 'center'
   }
 }))
 
@@ -28,7 +31,7 @@ function EmailBody (props) {
   return (
     <div>
       <h2>Please email the following to someone at your company who can sign the CLA:</h2>
-      <p><i>If you don't know who that is you can start with your manager or director.</i></p>
+      <p><i>If you don't know who that is, you can start with your manager or director.</i></p>
       <ReactMarkdown source={ClaRequestCorporate} />
     </div>
   )
@@ -51,8 +54,8 @@ function SignCheck (props) {
   return (
     <Paper elevation={23} className={classes.root}>
       <h2 className={classes.h2}>Are you authorized to sign legal agreements for your company?</h2>
-      <p>
-        Typically, this means you are an executive (e.g. CEO or CTO) or officer that is explicitly
+      <p className={classes.textCenter}>
+        Typically, this means you are an executive (e.g., CEO or CTO) or officer that is explicitly
         authorized by your company's board.
       </p>
       <Grid container spacing={3} justify="center">

--- a/common/model/agreement.js
+++ b/common/model/agreement.js
@@ -192,6 +192,11 @@ class agreement {
   static fromDocumentSnapshot (doc) {
     const data = doc.data()
     const signer = new Identity(IdentityType.EMAIL, data.signer.name, data.signer.value)
+    // TODO: create new signer class that extends Identity and provides
+    //  additional attributes such as title and phone numbe
+    // For now augment instance with missing keys so we can show them in the UI.
+    signer.title = data.signer.title
+    signer.phoneNumber = data.signer.phoneNumber
     let a
     if (data.type === AgreementType.INDIVIDUAL) {
       a = new Agreement(data.type, data.body, signer)


### PR DESCRIPTION
- Fix typos / terminology
- Add more context in the sign in page
- Display agreement ID and signature info when viewing a CLA (via the same form fields used to sign, set to read-only mode)
