### PR TITLE
Fix race condition caused by tests deleting firestore data of other test cases

### DIFF
--- a/functions/package.json
+++ b/functions/package.json
@@ -34,19 +34,20 @@
     "babel": "^6.23.0",
     "babel-eslint": "^10.0.3",
     "babel-jest": "^25.1.0",
-    "@firebase/testing": "^0.16.6",
+    "@firebase/testing": "^0.16.9",
     "eslint": "^6.8.0",
     "eslint-config-standard": "^14.1.0",
     "eslint-plugin-import": "^2.20.0",
     "eslint-plugin-node": "^11.0.0",
     "eslint-plugin-promise": "^4.2.1",
     "eslint-plugin-standard": "^4.0.1",
-    "firebase-tools": "^7.12.1",
-    "firebase-functions-test": "^0.1.6",
+    "firebase-tools": "^7.13.1",
+    "firebase-functions-test": "^0.1.7",
     "jest": "^25.1.0",
     "nock": "^10.0.0",
     "request-promise": "^4.2.5",
-    "smee-client": "^1.0.2"
+    "smee-client": "^1.0.2",
+    "@types/jest": "^25.1.0"
   },
   "engines": {
     "node": "10"

--- a/functions/test/github.test.js
+++ b/functions/test/github.test.js
@@ -1,8 +1,7 @@
 import {
   addAndGetSnapshot,
   setAndGetSnapshot,
-  setupDbAdmin,
-  teardownDb
+  setupEmulatorAdmin
 } from './helpers'
 
 const sha1 = require('sha1')
@@ -23,12 +22,12 @@ const createCommentUri = '/repos/bocon13/cla-test/issues/3/comments'
 const existingCommentUri = '/repos/bocon13/cla-test/issues/comments/1'
 
 const appId = 123
-const projectId = 'github-test-' + new Date()
 
 nock.disableNetConnect()
 
 describe('Github lib', () => {
   let db
+  let app
   let github
   let contribsRef
   let eventsRef
@@ -47,7 +46,9 @@ describe('Github lib', () => {
   })
 
   beforeEach(async () => {
-    db = await setupDbAdmin(null, projectId)
+    const firebase = await setupEmulatorAdmin(null)
+    app = firebase.app
+    db = firebase.db
     contribsRef = db.collection('contributions')
     eventsRef = db.collection('events')
     whitelistsRef = db.collection('whitelists')
@@ -72,8 +73,8 @@ describe('Github lib', () => {
     }
   })
 
-  afterAll(() => {
-    return teardownDb()
+  afterEach(() => {
+    return app.delete()
   })
 
   test('PR open event should be stored in the db', async () => {

--- a/functions/test/helpers.js
+++ b/functions/test/helpers.js
@@ -1,14 +1,15 @@
 const firebase = require('@firebase/testing')
 
 /**
- * Returns a firestore instance that can be accessed as the user defined in the
- * given auth object, optionally pre-populated with the given data.
- * @param {{ uid: String, email: String }} auth identifiers
- * @param data {Object|null}
- * @param projectId {string|null}
- * @returns {Promise<FirebaseFirestore.Firestore>}
+ * Returns a firebase app and corresponding firestore instance that can be
+ * accessed as the user defined in the given auth object, optionally
+ * pre-populated with the given data.
+ * @param auth
+ * @param data
+ * @param projectId
+ * @returns {Promise<{app: firebase.app.App, db: FirebaseFirestore.Firestore}>}
  */
-module.exports.setupDb = async (auth, data, projectId = null) => {
+module.exports.setupEmulator = async (auth, data, projectId = null) => {
   if (!projectId) {
     projectId = `test-${Date.now()}`
   }
@@ -43,18 +44,21 @@ module.exports.setupDb = async (auth, data, projectId = null) => {
   //   rules: fs.readFileSync('../../../firestore.rules', 'utf8')
   // })
 
-  return db
+  return {
+    app: app,
+    db: db
+  }
 }
 
 /**
- * Returns a firestore instance that can be accessed as admin, optionally
- * populated with the given data object.
+ * Returns a firebase app and corresponding instance that can be accessed as
+ * admin, optionally populated with the given data object.
  * @param {Object|null} data
  * @param projectId {string|null}
- * @returns {Promise<FirebaseFirestore.Firestore>}
+ * @returns {Promise<{app: firebase.app.App, db: FirebaseFirestore.Firestore}>}
  */
-module.exports.setupDbAdmin = async (data, projectId = null) => {
-  return module.exports.setupDb(null, data)
+module.exports.setupEmulatorAdmin = async (data, projectId = null) => {
+  return module.exports.setupEmulator(null, data, projectId)
 }
 
 /**
@@ -67,10 +71,6 @@ module.exports.clearDb = async (projectId) => {
   return firebase.clearFirestoreData({
     projectId: projectId
   })
-}
-
-module.exports.teardownDb = async () => {
-  await Promise.all(firebase.apps().map(app => app.delete()))
 }
 
 module.exports.addAndGetSnapshot = async (collectionRef, document) => {


### PR DESCRIPTION
Fixes #110

This patch refactors how the emulated firebase app and db (firestore) are
instantiated and terminated, allowing test cases to operate on their own
firestore instance, independently of other test cases. This is required
since Jest executes tests in parallel. Before, we were seeing a race
condition where a test case was deleting the app, and hence the
firestore instance, while that was still used by other test cases.