### PR TITLE
Returning back to the right page from Agreement details page

### DIFF
--- a/client/src/js/addendum/AddendumContainer.jsx
+++ b/client/src/js/addendum/AddendumContainer.jsx
@@ -134,12 +134,11 @@ function AddendumContainer (props) {
   }
 
   const confirmLeave = (val) => {
-    console.log(val)
     if (val === false) {
       setOpenDialog(false)
       return
     }
-    history.push('/')
+    history.goBack()
   }
 
   const goBack = () => {
@@ -151,7 +150,7 @@ function AddendumContainer (props) {
       return
     }
 
-    history.push('/')
+    history.goBack()
   }
 
   const updateForm = (


### PR DESCRIPTION
**Describe the PR**
Use the browser history to go back to the previous page instead of returning to the home page.
Note that if you're navigating from an admin page with a filter applied to the table you'll go back to the page but the filter will be lost as it's not persisted anywhere in the url parameters.

Fixes #139
