### PR TITLE
Store github events using lower-case identity key

### DIFF
--- a/functions/lib/cla.js
+++ b/functions/lib/cla.js
@@ -83,7 +83,7 @@ function Cla (db) {
   }
 
   /**
-   * Promises and object describing whether all given identities are
+   * Promises an object describing whether all given identities are
    * whitelisted, or not.
    * @param identities {{..., type: string, value: string}[]}
    * @returns {Promise<{allWhitelisted: boolean, missingIdentities: string[]}>}
@@ -97,7 +97,6 @@ function Cla (db) {
       })
     }
 
-    // Normalize keys to simplify DB queries.
     let identityKeys
     try {
       identityKeys = identities.map(util.identityKey)

--- a/functions/lib/github.js
+++ b/functions/lib/github.js
@@ -100,7 +100,10 @@ function Github (appId, privateKey, secret, db) {
     }
 
     // Check whitelist
-    event.identity = `github:${pr.user.login}`
+    event.identity = util.identityKey({
+      type: 'github',
+      value: pr.user.login
+    })
     try {
       if (await Cla(db).isIdentityWhitelisted(util.identityObj(event.identity))) {
         status.state = 'success'
@@ -112,7 +115,7 @@ function Github (appId, privateKey, secret, db) {
           'this is the ONF bot 🤖 I\'m glad you want to contribute to ' +
           'our projects! However, before accepting your contribution, ' +
           'we need to ask you to sign a Contributor License Agreement ' +
-          '(CLA). You can do it online, it will take only few minutes:' +
+          '(CLA). You can do it online, it will take only a few minutes:' +
           '\n\n✒️ 👉 https://cla.opennetworking.org\n\n' +
           'After signing, make sure to add your Github user ID ' +
           `\`${pr.user.login}\` to the agreement.`


### PR DESCRIPTION
Identity validation should be case insensitive. For this reason, when creating or updating a whitelist, we transform identity objects (e.g., `{type: 'github', value" 'FooBar'}`) into lower-case strings called identity keys (e.g., `github:foobar`). When a whitelist is updated, we look for previously failed events by querying the DB using the newly added identity keys. But queries in Firestore are case sensitive, and before this patch, we were storing Github events without making the identity key lower-case, thus failing to find previously failed events for the added identity.

With this patch, we make sure that identity keys for Github events undergo the same case transformations when creating/updating the whitelist.

Fixes #133