### PR TITLE
Update Crowd users with list of verified emails addresses

### DIFF
--- a/functions/index.js
+++ b/functions/index.js
@@ -191,6 +191,19 @@ exports.handleAppUserAccountUpdate = functions.firestore
   })
 
 /**
+ * Periodically reconcile data in crowd in case of one-off errors with
+ * snapshot-based handleAppUserAccountUpdate.
+ */
+exports.reconcileCrowd = functions.pubsub
+  .schedule('every 24 hours')
+  .onRun(() => {
+    return db.collection('appUsers').get()
+      .then(query => {
+        return Promise.all(query.docs.map(d => crowd.updateCrowdUser(d.id)))
+      })
+  })
+
+/**
  * Periodically Sync from Crowd to Github
  */
 exports.crowdToGithubPeriodicAudit = functions.pubsub

--- a/functions/lib/crowd.js
+++ b/functions/lib/crowd.js
@@ -1,6 +1,7 @@
 const rp = require('request-promise')
 const functions = require('firebase-functions')
 const sha1 = require('sha1')
+const admin = require('firebase-admin')
 
 module.exports = Crowd
 
@@ -9,7 +10,7 @@ module.exports = Crowd
  * @param db {FirebaseFirestore.Firestore}
  * @param appName {string} crowd app name
  * @param appPassword {string} crowd app password
- * @return {{setAppUserAccount: setAppUserAccount}}
+ * @return  * @return {{setAppUserAccount: setAppUserAccount, getUsersWithGithubID: (function(*=): {}), updateCrowdUser: (function(string): Promise<* | void>)}}
  * @constructor
  */
 function Crowd (db, appName, appPassword) {
@@ -70,6 +71,7 @@ function Crowd (db, appName, appPassword) {
         active: crowdUser.active,
         name: crowdUser['display-name'],
         email: crowdUser.email,
+        verified_emails: [],
         updatedOn: new Date()
       }
       // We got what we needed. User logout.
@@ -104,12 +106,27 @@ function Crowd (db, appName, appPassword) {
     //  this we need the removed crowd username. This can be found in the
     //  Firestore document change snapshot (old value).
     const attributeMap = {
-      github_id: []
+      // A set because a Crowd attribute can hold many values, but in reality we
+      // support binding to only one github ID.
+      github_id: new Set(),
+      // We assume as verified the following email addresses:
+      // - Used for sign up in Firebase app
+      // - Public one from Github profile
+      verified_emails: new Set()
     }
-    return db.collection('appUsers')
-      .doc(uid)
-      .collection('accounts')
-      .get()
+    // Fetch firebase user record from the admin SDK.
+    return admin.auth().getUser(uid)
+      .then(userRecord => {
+        if (userRecord.email && userRecord.emailVerified) {
+          attributeMap.verified_emails.add(userRecord.email)
+        }
+      })
+      .catch(error => {
+        console.log('Error fetching Firebase user record:', error)
+      })
+      // Fetch account data from firestore.
+      .then(() => db.collection('appUsers')
+        .doc(uid).collection('accounts').get())
       .then(query => {
         const accounts = query.docs.map(d => d.data())
         let crowdUsername = null
@@ -119,7 +136,10 @@ function Crowd (db, appName, appPassword) {
               crowdUsername = a.username
               break
             case 'github.com':
-              attributeMap.github_id = [a.username]
+              attributeMap.github_id.add(a.username)
+              if (a.email) {
+                attributeMap.verified_emails.add(a.email)
+              }
               break
             default:
               console.log(`Unrecognized account hostname ${a.hostname} for uid ${uid}, ignoring`, a)
@@ -135,7 +155,7 @@ function Crowd (db, appName, appPassword) {
         Object.keys(attributeMap).forEach(name => {
           attributes.push({
             name: name,
-            values: attributeMap[name]
+            values: Array.from(attributeMap[name])
           })
         })
         console.log(`Pushing attribute for crowd user ${crowdUsername}`, attributes)

--- a/functions/lib/crowd.js
+++ b/functions/lib/crowd.js
@@ -110,8 +110,8 @@ function Crowd (db, appName, appPassword) {
       // support binding to only one github ID.
       github_id: new Set(),
       // We assume as verified the following email addresses:
-      // - Used for sign up in Firebase app
-      // - Public one from Github profile
+      // - The one used to sign up in the Firebase app
+      // - The public one from the Github profile
       verified_emails: new Set()
     }
     // Fetch firebase user record from the admin SDK.

--- a/functions/lib/crowd.js
+++ b/functions/lib/crowd.js
@@ -10,7 +10,7 @@ module.exports = Crowd
  * @param db {FirebaseFirestore.Firestore}
  * @param appName {string} crowd app name
  * @param appPassword {string} crowd app password
- * @return  * @return {{setAppUserAccount: setAppUserAccount, getUsersWithGithubID: (function(*=): {}), updateCrowdUser: (function(string): Promise<* | void>)}}
+ * @return {setAppUserAccount: setAppUserAccount, getUsersWithGithubID: (function(*=): {}), updateCrowdUser: (function(string): Promise<* | void>)}}
  * @constructor
  */
 function Crowd (db, appName, appPassword) {


### PR DESCRIPTION
We assume as verified the following email addresses:
- The one used to sign up in the Firebase app
- The public one from linked Github profile

Values are stored in a Crowd user attributed named `verified_emails`.

We also add a periodic function (every 24 hours) to reconcile data in Crowd in case of one-off errors with updates triggered by account linking events.