### PR TITLE
Adding firebase tool to circleci Docker image

### DIFF
--- a/.circleci/Dockerfile
+++ b/.circleci/Dockerfile
@@ -13,3 +13,5 @@ RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 0xB1998361
 RUN apt-get update && apt-get install -y --no-install-recommends \
     zulu-11 \
     && rm -rf /var/lib/apt/lists/*
+
+RUN npm install -g firebase-tools


### PR DESCRIPTION
**Describe the PR**
Adding `firebase` to the Docker image used in the test so that we can a `firebase:emulator` in there

Fixes #
