### PR TITLE
Fix Crowd Webhook to ignore some Github events

### DIFF
--- a/functions/lib/crowd_webhook.js
+++ b/functions/lib/crowd_webhook.js
@@ -51,6 +51,12 @@ function CrowdWebhook (groupMappings, github) {
       }
     } else if (event.type === 'USER_UPDATED_GITHUB') {
       if (event.user && event.user.groups) {
+        if (event.oldGithubId === event.newGithubId) {
+          console.log(`Received USER_UPDATED_GITHUB for ${event.user.username} ` +
+                      `with same old and new Github IDs: ${event.user.githubId}. ` +
+                      "Discarding event...");
+          return;
+        }
         for (const group of event.user.groups) {
           await removeMembership({ githubId: event.oldGithubId }, group, ['github'])
           await addMembership(event.user, group, ['github'])

--- a/functions/lib/crowd_webhook.js
+++ b/functions/lib/crowd_webhook.js
@@ -54,7 +54,7 @@ function CrowdWebhook (groupMappings, github) {
         if (event.oldGithubId === event.newGithubId) {
           console.log(`Received USER_UPDATED_GITHUB for ${event.user.username} ` +
                       `with same old and new Github IDs: ${event.user.githubId}. ` +
-                      "Discarding event...");
+                      'Discarding event...')
           return;
         }
         for (const group of event.user.groups) {

--- a/functions/lib/crowd_webhook.js
+++ b/functions/lib/crowd_webhook.js
@@ -55,7 +55,7 @@ function CrowdWebhook (groupMappings, github) {
           console.log(`Received USER_UPDATED_GITHUB for ${event.user.username} ` +
                       `with same old and new Github IDs: ${event.user.githubId}. ` +
                       'Discarding event...')
-          return;
+          return
         }
         for (const group of event.user.groups) {
           await removeMembership({ githubId: event.oldGithubId }, group, ['github'])

--- a/functions/test/crowd_events/user_updated_github_with_group_noop.json
+++ b/functions/test/crowd_events/user_updated_github_with_group_noop.json
@@ -1,0 +1,14 @@
+{
+  "type": "USER_UPDATED_GITHUB",
+  "user": {
+    "username": "test",
+    "email": "test@test",
+    "name": "tester",
+    "groups": [
+      "foo"
+    ],
+    "githubId": "tester_github"
+  },
+  "oldGithubId": "tester_github",
+  "newGithubId": "tester_github"
+}

--- a/functions/test/crowd_webhook.test.js
+++ b/functions/test/crowd_webhook.test.js
@@ -122,4 +122,10 @@ describe('Crowd Webhook lib', () => {
       { org: 'github_org2', team: 'team2', user: 'tester_github' }
     ])
   })
+
+  test('user updated github with group without user change', async function () {
+    await crowdWebhook.processEvent(require('./crowd_events/user_updated_github_with_group_noop'))
+    expect(github.added).toEqual([])
+    expect(github.removed).toEqual([])
+  })
 })


### PR DESCRIPTION
Drop USER_UPDATED_GITHUB events where the old and new Github IDs are identical.

TODO:
- [x] add unit test that covers this case