### PR TITLE
Fixing the permissions to list all the available identities

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -61,7 +61,7 @@ service cloud.firestore {
         }
 
         match /whitelists/{whitelistId} {
-            allow read:   if isSignedIn(request.auth) && isWhitelistManager(request.auth, resource.data);
+            allow read:   if isSignedIn(request.auth) && (isAdmin(request.auth) || isWhitelistManager(request.auth, resource.data));
         }
 
         match /appUsers/{uid} {

--- a/test/rules.test.js
+++ b/test/rules.test.js
@@ -122,6 +122,11 @@ describe('CLAM Firestore rules TestSuite', () => {
       otherAgreement = await app.collection(agreementCollection).add({
         signer: {value: 'non-admin@onf.org'},
       })
+
+      // this entry in the whitelist is only used to test that the Admin can read it
+      await app.collection(whitelistCollection).doc("foo").set({
+        values: ['email:wl1@opennetworking.org', 'email:foo@opennetworking.org']
+      }, { merge: true })
     })
 
     it('should be allowed to list all the Agreements', async () => {
@@ -147,6 +152,13 @@ describe('CLAM Firestore rules TestSuite', () => {
       }
 
       await firebase.assertFails(db.collection(addendumCollection).add(addendum))
+    });
+
+    it('should be allowed to list all the identities', async () => {
+      const whitelist = db.collection(whitelistCollection);
+      const query = whitelist.get();
+      const res = await firebase.assertSucceeds(query);
+      assert.strictEqual(res.docs.length, 1);
     });
   });
 


### PR DESCRIPTION
**Describe the PR**
As of now and `Admin` cannot list all the `Identities` because of a permission issue.
This will fix it.
