### PR TITLE
Adding printer dedicated CSS to style Agreement page

### DIFF
--- a/client/public/assets/print.css
+++ b/client/public/assets/print.css
@@ -1,0 +1,18 @@
+@media print {
+    header, .print-hidden {
+        display: none !important;
+    }
+
+    .cla-text-container {
+        overflow-y: visible !important;
+        max-height: max-content !important;
+    }
+
+    .print-no-shade * {
+        box-shadow: none !important;
+    }
+
+    .print-no-padding {
+        padding: 0 !important;
+    }
+}

--- a/client/public/index.html
+++ b/client/public/index.html
@@ -6,8 +6,9 @@
     <title>ONF CLA Manager</title>
 
     <link rel="shortcut icon" href="assets/favicon.ico" type="image/x-icon">
-    <link rel="icon" href="assets/favicon.ico" type="image/x-icon">
+    <link rel="icon" href="/assets/favicon.ico" type="image/x-icon">
     <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons">
+    <link rel="stylesheet" media="print" href="/assets/print.css" />
 
     <style>
       html, body, #root {

--- a/client/src/js/AppRouter.jsx
+++ b/client/src/js/AppRouter.jsx
@@ -48,7 +48,7 @@ class AppRouter extends React.Component {
             onSignOut={this.signOut}
             isAdmin={this.props.isAdmin}
           />
-          <Container>
+          <Container className={'print-no-shade print-no-padding'}>
             <Route
               path='/' exact render={() => (
               <Home user={user}/>

--- a/client/src/js/addendum/AddendumContainer.jsx
+++ b/client/src/js/addendum/AddendumContainer.jsx
@@ -92,7 +92,7 @@ function AddendumContainer (props) {
         </Dialog>
         <Link to="#" onClick={goBack}>
           <Button
-            className={classes.back}
+            className={'print-hidden'}
             variant='contained'
             color='primary'
             size='large'

--- a/client/src/js/addendum/AddendumForm.jsx
+++ b/client/src/js/addendum/AddendumForm.jsx
@@ -192,7 +192,7 @@ function AddendumForm (props) {
     'Identities to/from this Agreement AND to add and remove other Managers to/from this Agreement.'
 
   const updateForm = (
-    <div className={classes.updateFormContainer + ' AddendumContainer__update-form '}>
+    <div className={classes.updateFormContainer + ' AddendumContainer__update-form print-hidden'}>
       <Grid item xs={12}>
         <Grid container spacing={2}>
 

--- a/client/src/js/addendum/IdentityCard.jsx
+++ b/client/src/js/addendum/IdentityCard.jsx
@@ -81,7 +81,7 @@ function IdentityCard (props) {
         {props.callback
           ? <Grid item xs={2}>
             <CardContent>
-              <Box textAlign='right' m={1}>
+              <Box textAlign='right' m={1} className={'print-hidden'}>
                 <Link href='#' onClick={props.callback(props.identity)}>
                   <IconButton size='small' color='primary'>
                     {props.type === 'default' ? <DeleteIcon/> : null}

--- a/client/src/js/agreement/AgreementDisplay.jsx
+++ b/client/src/js/agreement/AgreementDisplay.jsx
@@ -27,7 +27,7 @@ const useStyles = makeStyles(theme => ({
 function AgreementDisplay (props) {
   const classes = useStyles()
   return (
-    <Card variant='outlined' className={classes.root}>
+    <Card variant='outlined' className={classes.root + ' cla-text-container'}>
       <ReactMarkdown source={props.text} />
     </Card>
   )


### PR DESCRIPTION
**Describe the PR**
Adding CSS styles for media=print to hide unwanted elements when printing and expanding the text scrollboxes.

Here's an example of the printed output
[ONF CLA Manager.pdf](https://github.com/OpenNetworkingFoundation/cla-manager/files/5851923/ONF.CLA.Manager.pdf)

