### PR TITLE
Make sure identities are saved in the Addendums and in the Whitelist …

### DIFF
--- a/common/model/identity.js
+++ b/common/model/identity.js
@@ -33,8 +33,8 @@ export class Identity {
     }
 
     this._type = type
-    this._name = name
-    this._value = value
+    this._name = name.trim()
+    this._value = value.trim()
   }
 
   /**

--- a/common/model/identity.test.js
+++ b/common/model/identity.test.js
@@ -1,5 +1,23 @@
 import { Identity, IdentityType } from './identity'
 
+// define a custom validator for whitespaces
+expect.extend({
+  toHaveWhitespaces (received) {
+    const pass = (received.indexOf(' ') !== -1)
+    if (pass) {
+      return {
+        pass: true,
+        message: () => `expected "${received}" not to have whitespaces`
+      }
+    } else {
+      return {
+        pass: false,
+        message: () => `expected "${received}" to have whitespaces`
+      }
+    }
+  }
+})
+
 describe('The Identity model', () => {
   let emailModel, githubModel
   beforeEach(() => {
@@ -15,6 +33,12 @@ describe('The Identity model', () => {
     expect(githubModel.type).toEqual(IdentityType.GITHUB)
     expect(githubModel.name).toEqual('githubModel')
     expect(githubModel.value).toEqual('githubId')
+  })
+
+  it('should trim whitespaces from values', () => {
+    const contributorWithSpaces = new Identity(IdentityType.GITHUB, 'Mike', '   i-have-some-spaces   ')
+
+    expect(contributorWithSpaces.value).not.toHaveWhitespaces()
   })
 
   it('should not accept an invalid type', function () {

--- a/functions/lib/util.js
+++ b/functions/lib/util.js
@@ -8,7 +8,7 @@ module.exports.identityKey = function (identityObj) {
     throw new Error('Invalid identity object')
   }
   const lcValue = identityObj.value.toLowerCase()
-  return `${identityObj.type}:${lcValue}`
+  return `${identityObj.type}:${lcValue.trim()}`
 }
 
 /**


### PR DESCRIPTION
…without whitespaces, closes #213

**Describe the PR**
Adds checks both in the client and function code to avoid whitespaces in the stored `Identities`

Fixes #213 
