### PR TITLE
Partial revert of 035cd962d6b8343136795a6305b86252c4895b35

### DIFF
--- a/client/src/js/addendum/AddendumContainer.jsx
+++ b/client/src/js/addendum/AddendumContainer.jsx
@@ -24,7 +24,7 @@ const useStyles = makeStyles(theme => ({
 }))
 
 /**
- * Component which given an Agreement displays a listAllAccounts of associated addendums
+ * Component which given an Agreement displays a list of associated addendums
  */
 function AddendumContainer (props) {
 

--- a/client/src/js/addendum/AddendumForm.jsx
+++ b/client/src/js/addendum/AddendumForm.jsx
@@ -56,7 +56,7 @@ class AddendumFormCtrl {
 }
 
 /**
- * Component which given an Agreement displays a listAllAccounts of associated addendums
+ * Component which given an Agreement displays a list of associated addendums
  */
 function AddendumForm (props) {
 
@@ -183,8 +183,8 @@ function AddendumForm (props) {
   identityType[AddendumType.MANAGER] = 'Manager'
 
   const subtitle = {}
-  subtitle[AddendumType.CONTRIBUTOR] = 'Here is a listAllAccounts of Users/Identities that are authorized to make contributions to ONF projects under this agreement'
-  subtitle[AddendumType.MANAGER] = 'Here is a listAllAccounts of Users/Identities that are allowed to add and remove Contributor Identities to/from this Agreement'
+  subtitle[AddendumType.CONTRIBUTOR] = 'Here is a list of Users/Identities that are authorized to make contributions to ONF projects under this agreement'
+  subtitle[AddendumType.MANAGER] = 'Here is a list of Users/Identities that are allowed to add and remove Contributor Identities to/from this Agreement'
 
   const text = {}
   text[AddendumType.CONTRIBUTOR] = 'Users/Identities listed under "Contributors" for this Agreement will be allowed to make contributions to ONF projects.'
@@ -266,7 +266,7 @@ function AddendumForm (props) {
           agreement. The last one was signed
           on: {lastAddendum ? lastAddendum.dateSigned.toString() : 'NEVER'}</p>
       </Grid>
-      {/* TODO print a listAllAccounts of all the addendums if it's admin */}
+      {/* TODO print a list of all the addendums if it's admin */}
       {canManage ? updateForm : null}
 
     </Grid>

--- a/client/src/js/admin/AdminNavigation.test.js
+++ b/client/src/js/admin/AdminNavigation.test.js
@@ -26,11 +26,11 @@ describe('AdminNav Component Test Suite', () => {
   })
 
   describe('when clicking on a menu item', () => {
-    it('should send me to the agreement listAllAccounts', () => {
+    it('should send me to the agreement list', () => {
       wrapper.find(MenuItem).first().simulate('click')
       expect(historyMock.push).toBeCalledWith('/admin/agreements')
     })
-    it('should send me to the identities listAllAccounts', () => {
+    it('should send me to the identities list', () => {
       wrapper.find(MenuItem).at(1).simulate('click')
       expect(historyMock.push).toBeCalledWith('/admin/identities')
     })

--- a/common/model/addendum.test.js
+++ b/common/model/addendum.test.js
@@ -33,7 +33,7 @@ describe('The Addendum model', () => {
     expect(model.dateSigned instanceof Date).toBe(true)
   })
 
-  describe('the listAllAccounts method', () => {
+  describe('the list method', () => {
     it('should return all the agreements in the DB', (done) => {
       firestoreMock.mockGetReturn = {
         docs: [

--- a/common/model/agreement.js
+++ b/common/model/agreement.js
@@ -156,7 +156,7 @@ class agreement {
   }
 
   /**
-   * Returns a listAllAccounts of Addendum associated with this listAllAccounts
+   * Returns a list of Addendum associated with this list
    * @param {AddendumType}  type  The type of addendums to load
    * @returns {Promise<Addendum[]>}
    */

--- a/common/model/agreement.test.js
+++ b/common/model/agreement.test.js
@@ -134,7 +134,7 @@ describe('The Agreement model', () => {
   })
 
   describe('the getAddendums method', () => {
-    it('should return a listAllAccounts of CONTRIBUTOR addendums', (done) => {
+    it('should return a list of CONTRIBUTOR addendums', (done) => {
       firestoreMock.mockGetReturn = {
         docs: [
           { data: () => new Addendum(AddendumType.CONTRIBUTOR, 'test-id', signer, [user1, user2], []).toJson() },
@@ -154,7 +154,7 @@ describe('The Agreement model', () => {
         })
         .catch(done)
     })
-    it('should return a listAllAccounts of MANAGER addendums', (done) => {
+    it('should return a list of MANAGER addendums', (done) => {
       firestoreMock.mockGetReturn = {
         docs: [
           { data: () => new Addendum(AddendumType.MANAGER, 'test-id', signer, [user1], []).toJson() }
@@ -174,7 +174,7 @@ describe('The Agreement model', () => {
   })
 
   describe('the getWhitelist method', () => {
-    it('should return a listAllAccounts of valid users for an agreement ', (done) => {
+    it('should return a list of valid users for an agreement ', (done) => {
       firestoreMock.mockGetReturn = {
         docs: [
           { data: () => new Addendum(AddendumType.CONTRIBUTOR, 'test-id', signer, [user1, user2], []).toJson() },
@@ -194,7 +194,7 @@ describe('The Agreement model', () => {
   })
 
   describe('the subscribe method', () => {
-    it('should get a listAllAccounts of models from the DB', (done) => {
+    it('should get a list of models from the DB', (done) => {
       firestoreMock.mockOnSnaptshotSuccess = { docs: [] }
       firestoreMock.mockGetReturn = { docs: [] }
       const email = 'info@onf.org'
@@ -213,7 +213,7 @@ describe('The Agreement model', () => {
     })
   })
 
-  describe('the listAllAccounts method', () => {
+  describe('the list method', () => {
     it('should return all the agreements in the DB', (done) => {
       firestoreMock.mockGetReturn = {
         docs: [

--- a/common/model/identity.js
+++ b/common/model/identity.js
@@ -91,7 +91,7 @@ export class Identity {
   }
 
   /**
-   * Returns the listAllAccounts ov valid IdentityTypes.
+   * Returns the list ov valid IdentityTypes.
    *
    * @returns {string[]}
    */

--- a/common/model/whitelists.test.js
+++ b/common/model/whitelists.test.js
@@ -46,7 +46,7 @@ describe('The Whitelist model', () => {
     DBSpy.mockClear()
     firestoreMock.reset()
   })
-  it('should listAllAccounts all the entries in the DB', (done) => {
+  it('should list all the entries in the DB', (done) => {
     firestoreMock.mockGetReturn = {
       docs: [wl1, wl2, wl3]
     }
@@ -79,7 +79,7 @@ describe('The Whitelist model', () => {
       .catch(done)
   })
 
-  it('should return a listAllAccounts of identities with the associated agreements', (done) => {
+  it('should return a list of identities with the associated agreements', (done) => {
     firestoreMock.mockGetReturn = {
       docs: [wl1, wl2, wl3]
     }

--- a/functions/index.js
+++ b/functions/index.js
@@ -68,7 +68,7 @@ const processEvent = async (eventSnapshot) => {
 
 /**
  * When a new addendum is created, update the whitelists collection with the
- * listAllAccounts of allowed identities for the parent agreement.
+ * list of allowed identities for the parent agreement.
  */
 exports.updateWhitelist = functions.firestore
   .document('/addendums/{id}')

--- a/functions/lib/github.js
+++ b/functions/lib/github.js
@@ -310,10 +310,10 @@ function Github (appId, privateKey, secret, db) {
   }
 
   /**
-   * Fetch user listAllAccounts from a GitHub Team
+   * Fetch user list from a GitHub Team
    * @param org {GitHub Organization name}
    * @param team {GitHub Team name}
-   * @return {list} user listAllAccounts
+   * @return {list} user list
    */
   async function getUsers (org, team) {
     const octokit = await getApi(org)
@@ -336,7 +336,7 @@ function Github (appId, privateKey, secret, db) {
         validUsers[user.login] = true
       }
     } catch (e) {
-      throw new Error('Fetching user listAllAccounts failed:' + e)
+      throw new Error('Fetching user list failed:' + e)
     }
     return validUsers
   }

--- a/test/rules.test.js
+++ b/test/rules.test.js
@@ -129,7 +129,7 @@ describe('CLAM Firestore rules TestSuite', () => {
       }, { merge: true })
     })
 
-    it('should be allowed to listAllAccounts all the Agreements', async () => {
+    it('should be allowed to list all the Agreements', async () => {
       const agreements = db.collection(agreementCollection);
       const query = agreements.get();
       const res = await firebase.assertSucceeds(query);
@@ -191,7 +191,7 @@ describe('CLAM Firestore rules TestSuite', () => {
 
     });
 
-    it('should only be allowed to listAllAccounts his own Agreements', (done) => {
+    it('should only be allowed to list his own Agreements', (done) => {
 
       const queryAll = agreements.get();
       firebase.assertFails(queryAll);
@@ -237,7 +237,7 @@ describe('CLAM Firestore rules TestSuite', () => {
         const query = await app.collection(whitelistCollection).get()
       });
 
-      it('should be able to listAllAccounts those Agreements', async () => {
+      it('should be able to list those Agreements', async () => {
 
         // get all the agreements this user can manage from the whitelist
         const query = await managerDb.collection(whitelistCollection)


### PR DESCRIPTION
**Describe the PR**
Restore the use of `list` on text and comments instead of `listAllAccounts`.