### PR TITLE
Handle the pagination when fetch Github users

### DIFF
--- a/functions/lib/github.js
+++ b/functions/lib/github.js
@@ -321,24 +321,24 @@ function Github (appId, privateKey, secret, db) {
     try {
       // Get in-team users
       await octokit.paginate(
-        "GET /orgs/{org}/teams/{team_slug}/members",
+        'GET /orgs/{org}/teams/{team_slug}/members',
         {
           org: org,
           team_slug: team,
-          per_page: 100,
+          per_page: 100
         },
-        (response) => response.data.map((member) => validUsers[member.login] = true)
-      );
+        (response) => response.data.map((member) => (validUsers[member.login] = true))
+      )
       // Get Pending users
       await octokit.paginate(
-        "GET /orgs/{org}/teams/{team_slug}/invitations",
+        'GET /orgs/{org}/teams/{team_slug}/invitations',
         {
           org: org,
           team_slug: team,
-          per_page: 100,
+          per_page: 100
         },
-        (response) => response.data.map((member) => validUsers[member.login] = true)
-      );
+        (response) => response.data.map((member) => (validUsers[member.login] = true))
+      )
     } catch (e) {
       throw new Error('Fetching user listAllAccounts failed:' + e)
     }

--- a/functions/lib/github.js
+++ b/functions/lib/github.js
@@ -320,21 +320,25 @@ function Github (appId, privateKey, secret, db) {
     const validUsers = {}
     try {
       // Get in-team users
-      var { data: users } = await octokit.teams.listMembersInOrg({
-        org: org,
-        team_slug: team
-      })
-      for (const user of users) {
-        validUsers[user.login] = true
-      }
+      await octokit.paginate(
+        "GET /orgs/{org}/teams/{team_slug}/members",
+        {
+          org: org,
+          team_slug: team,
+          per_page: 100,
+        },
+        (response) => response.data.map((member) => validUsers[member.login] = true)
+      );
       // Get Pending users
-      var { data: pendingUsers } = await octokit.teams.listPendingInvitationsInOrg({
-        org: org,
-        team_slug: team
-      })
-      for (const user of pendingUsers) {
-        validUsers[user.login] = true
-      }
+      await octokit.paginate(
+        "GET /orgs/{org}/teams/{team_slug}/invitations",
+        {
+          org: org,
+          team_slug: team,
+          per_page: 100,
+        },
+        (response) => response.data.map((member) => validUsers[member.login] = true)
+      );
     } catch (e) {
       throw new Error('Fetching user listAllAccounts failed:' + e)
     }


### PR DESCRIPTION
**Describe the PR**
All endpoint methods starting with .list* do not return all results at once but instead return the first 50 items by default

Fixes #
Use octokit's builtin method `octokit.paginate` to get users properly.