### PR TITLE
Change the API to handle the pagination when listing Github teams 

### DIFF
--- a/functions/lib/github.js
+++ b/functions/lib/github.js
@@ -395,17 +395,21 @@ function Github (appId, privateKey, secret, db) {
     const octokit = await getApi(org)
     try {
       let check = false
-      const { data: teams } = await octokit.teams.list({
-        org: org
-      })
-
-      // Check the existence
-      for (const team of teams) {
-        if (team.name === name) {
-          check = true
-          break
+      await octokit.paginate(
+        'GET /orgs/{org}/teams',
+        {
+          org: org,
+          per_page: 100
+        },
+        (response) => response.data.map((team) => team.name)
+      ).then((teams) => {
+        for (const team of teams) {
+          if (team === name) {
+            check = true // exist
+            break
+          }
         }
-      }
+      })
 
       // Create if necessary
       if (!check) {


### PR DESCRIPTION
**Describe the PR**
API` octokit.teams.list` returns at most 30 teams in its response but we have `41` teams so we have to call the function multiple times to collect full list.

Use the builtin function `octokit.paginate ` to iterate all responses.

Fixes #236 
