### PR TITLE
Get nested Crowd group members, not just direct group members

### DIFF
--- a/functions/lib/crowd.js
+++ b/functions/lib/crowd.js
@@ -226,7 +226,7 @@ function Crowd (db, appName, appPassword) {
   async function getUsersUnderGroup (group) {
     return rp.get({
       ...rpConf,
-      uri: baseUri + `/group/user/direct?groupname=${group}&max-results=3000`
+      uri: baseUri + `/group/user/nested?groupname=${group}&max-results=3000`
     })
   }
 


### PR DESCRIPTION
Change API from:  https://docs.atlassian.com/atlassian-crowd/4.3.0/REST/#usermanagement/1/group-getDirectMembersOfGroup

To:  https://docs.atlassian.com/atlassian-crowd/4.3.0/REST/#usermanagement/1/group-getNestedMembersOfGroup

Which allows  nested groups to be used in  Crowd.