### PR TITLE
Crowd auto update

### DIFF
--- a/client/src/js/AppRouter.jsx
+++ b/client/src/js/AppRouter.jsx
@@ -12,6 +12,7 @@ import AdminIdentitiesList from './admin/AdminIdentitiesList'
 import AppUserAccountsContainer from './user/AppUserAccountsContainer'
 import PermissionDenied from './admin/PermissionDenied'
 import AdminLinkedAccountList from './admin/AdminLinkedAccountsList'
+import AdminDomains from './admin/AdminDomains'
 
 class AppRouter extends React.Component {
   constructor (props) {
@@ -87,6 +88,14 @@ class AppRouter extends React.Component {
               path='/admin/linked-accounts' exact render={() => {
               if (this.props.isAdmin) {
                 return <AdminLinkedAccountList/>
+              }
+              return <PermissionDenied/>
+            }}
+            />
+            <Route
+              path='/admin/manage-domains' exact render={() => {
+              if (this.props.isAdmin) {
+                return <AdminDomains/>
               }
               return <PermissionDenied/>
             }}

--- a/client/src/js/admin/AdminDomains.jsx
+++ b/client/src/js/admin/AdminDomains.jsx
@@ -1,0 +1,187 @@
+import React, { useState } from 'react'
+import { makeStyles } from '@material-ui/core/styles'
+import { Grid, Paper } from '@material-ui/core'
+import MaterialTable from 'material-table'
+import { Domain } from '../../common/model/domain'
+import Fade from '@material-ui/core/Fade';
+import FormControlLabel from '@material-ui/core/FormControlLabel';
+import Switch from '@material-ui/core/Switch';
+import Alert from '@material-ui/lab/Alert';
+import IconButton from '@material-ui/core/IconButton';
+import Collapse from '@material-ui/core/Collapse';
+import CloseIcon from '@material-ui/icons/Close';
+
+const useStyles = makeStyles(theme => ({
+  root: {
+    padding: theme.spacing(2),
+    marginTop: theme.spacing(2)
+  }
+}))
+
+function AdminDomains (props) {
+  const classes = useStyles()
+  
+  const [validDomains, setValidDomains] = useState([])
+  const [invalidDomains, setInvalidDomains] = useState([])
+  
+  const [error, setError] = React.useState(false);
+  const [success, setSuccess] = React.useState(false);
+  
+  const [checked, setChecked] = React.useState(false);
+
+  const validDomainColumns = [
+    { title: 'Company Domain Name', field: 'name' },
+    { title: 'Validated On', field: 'createdOn', type: 'date', editable: 'never'},
+  ]
+
+  const invalidDomainColumns = [
+    { title: 'Company Domain Name', field: 'name' },
+    { title: 'Validated On', field: 'createdOn', type: 'date'},
+    { title: 'Invalidated On', field: 'deletedOn', type: 'date' }
+  ]
+
+  const handleChange = () => {
+    setChecked((prev) => !prev);
+  };
+    
+  React.useEffect(() => {
+    Domain.listValidDomains().then(res => {
+      setValidDomains(res)
+    })
+      .catch(console.error)
+  }, [])
+
+  React.useEffect(() => {
+    Domain.listInvalidDomains().then(res => {
+      setInvalidDomains(res)
+    })
+      .catch(console.error)
+  }, [])
+  
+  function formatDomain(domain) {
+    if (/^[a-zA-Z0-9][a-zA-Z0-9-]{0,61}[a-zA-Z0-9](?:\.[a-zA-Z]{2,})+$/.test(domain)) {
+      return true;
+    }
+    return false;
+  }
+
+  return (
+    <Paper elevation={23} className={classes.root}>
+      <Grid container spacing={2}>
+        <Grid item xs={12}>
+          <h2>Manage Domains</h2>
+          <p>This page let you see a list of all the approved domains</p>
+          <Collapse in={error}>
+            <Alert
+              severity="error"
+              action={
+                <IconButton
+                  aria-label="close"
+                  color="inherit"
+                  size="small"
+                  onClick={() => {
+                    setError(false);
+                  }}
+                >
+                  <CloseIcon fontSize="inherit" />
+                </IconButton>
+              }
+            >      
+              {error}
+            </Alert>
+          </Collapse>
+          <Collapse in={success}>
+            <Alert
+              severity="success"
+              action={
+                <IconButton
+                  aria-label="close"
+                  color="inherit"
+                  size="small"
+                  onClick={() => {
+                    setSuccess(false);
+                  }}
+                >
+                  <CloseIcon fontSize="inherit" />
+                </IconButton>
+              }
+            >
+              {success}
+            </Alert>
+          </Collapse>
+        </Grid>
+        <Grid item xs={12}>
+          <MaterialTable
+            title="Approved Domains"
+            columns={validDomainColumns}
+            data={validDomains}
+            options={{
+                sorting: true
+            }}
+            editable={{
+                onRowAdd: newData =>
+                new Promise((resolve, reject) => {
+                    setTimeout(() => {
+                    let isValid = formatDomain(newData.name)
+                    if(isValid || window.confirm("The domain you entered is formatted badly. Do you still wish to proceed?")) {
+                      Domain.checkIfDomainExists(newData.name).then((response) => {
+                        if(response) {
+                          setSuccess(false)
+                          setError("The domain " + newData.name + " already exists in the list of valid domains")
+                        } else {
+                          const domain = new Domain(null, newData.name, true)
+                          domain.validate().then((response) => setValidDomains([response, ...validDomains]))
+                          setError(false)
+                          setSuccess("The domain " + newData.name + " was successfully VALIDATED on " + domain._createdOn.toLocaleString())
+                        }
+                      })
+                    }
+                    resolve()
+                    }, 1000)
+                }),
+                onRowDelete: oldData =>
+                new Promise((resolve, reject) => {
+                    setTimeout(() => {
+                    const dataDelete = [...validDomains]
+                    const index = oldData.tableData.id
+                    dataDelete.splice(index, 1)
+                    oldData._deletedOn = new Date().toLocaleString()
+                    Domain.invalidate(oldData.id)
+                    setValidDomains([...dataDelete])
+                    setError(false)
+                    setSuccess("The domain " + oldData.name + " was successfully INVALIDATED on " + oldData._deletedOn)
+                    setInvalidDomains([oldData, ...invalidDomains])
+                    resolve()
+                    }, 1000)
+                }),
+            }}
+            />
+        </Grid>
+        <Grid item xs={12}>
+            <div className={classes.root}>
+                <FormControlLabel
+                    control={<Switch checked={checked} onChange={handleChange} />}
+                    label="See Invalid Domains"
+                />
+                <div className={classes.container}>
+                    <Fade in={checked} unmountOnExit>
+                        <Grid item xs={12}>
+                            <MaterialTable
+                                title="Invalid Domains"
+                                columns={invalidDomainColumns}
+                                data={invalidDomains}
+                                options={{
+                                    sorting: true
+                                }}
+                            />
+                        </Grid>
+                    </Fade>
+                </div>
+            </div>
+        </Grid>
+      </Grid>
+    </Paper>
+  )
+}
+
+export default AdminDomains

--- a/client/src/js/admin/AdminNavigation.jsx
+++ b/client/src/js/admin/AdminNavigation.jsx
@@ -46,6 +46,7 @@ function AdminNav (props) {
         <MenuItem onClick={handleClose('agreements')}>Agreements</MenuItem>
         <MenuItem onClick={handleClose('identities')}>Identities</MenuItem>
         <MenuItem onClick={handleClose('linked-accounts')}>Linked Accounts</MenuItem>
+        <MenuItem onClick={handleClose('manage-domains')}>Manage Domains</MenuItem>
       </Menu>
     </div>
   )

--- a/client/src/js/admin/AdminNavigation.test.js
+++ b/client/src/js/admin/AdminNavigation.test.js
@@ -22,7 +22,7 @@ describe('AdminNav Component Test Suite', () => {
   it('renders one button and one menu with two items', () => {
     expect(wrapper.find(Button)).toHaveLength(1)
     expect(wrapper.find(Menu)).toHaveLength(1)
-    expect(wrapper.find(MenuItem)).toHaveLength(3)
+    expect(wrapper.find(MenuItem)).toHaveLength(4)
   })
 
   describe('when clicking on a menu item', () => {

--- a/common/model/domain.js
+++ b/common/model/domain.js
@@ -5,7 +5,7 @@ const domainCollection = 'domains'
 /**
  * Domain model class.
  */
-class domain {
+export class Domain {
   /**
    * Creates a new domain
    * @param {string} id id of domain
@@ -70,7 +70,8 @@ class domain {
     return {
       name: this.name,
       valid: this.valid,
-      createdOn: this.createdOn
+      createdOn: this.createdOn,
+      deletedOn: this.deletedOn
     }
   }
 
@@ -157,5 +158,3 @@ class domain {
       })
   }
 }
-
-export const Domain = domain

--- a/common/model/domain.js
+++ b/common/model/domain.js
@@ -1,0 +1,161 @@
+import DB from '../db/db'
+
+const domainCollection = 'domains'
+
+/**
+ * Domain model class.
+ */
+class domain {
+  /**
+   * Creates a new domain
+   * @param {string} id id of domain
+   * @param {string} name name of domain
+   * @param {boolean} valid whether the domain is valid
+   * @param {Date} createdOn date domain was validated
+   * @param {Date|null} deletedOn date domain was invalidated (null if it is still valid)
+   */
+  constructor (id, name, valid, createdOn = new Date(), deletedOn = null) {
+    this._id = id
+    this._name = name
+    this._valid = valid
+    this._createdOn = createdOn
+    this._deletedOn = deletedOn
+  }
+
+  /**
+   * Returns the global identifier.
+   * @returns {string}
+   */
+  get id () {
+    return this._id
+  }
+
+  /**
+   * Returns the name
+   * @returns {string}
+   */
+  get name () {
+    return this._name
+  }
+
+  /**
+   * Returns the valid status
+   * @returns {boolean}
+   */
+  get valid () {
+    return this._valid
+  }
+
+  /**
+   * Returns the date the domain was validated
+   * @returns {Date}
+   */
+  get createdOn () {
+    return this._createdOn
+  }
+
+  /**
+   * Returns the date the domain was invalidated
+   * @returns {Date}
+   */
+  get deletedOn () {
+    return this._deletedOn
+  }
+
+  /**
+   * Returns the model in JSON compatible format.
+   * @returns {Object}
+   */
+  toJson () {
+    return {
+      name: this.name,
+      valid: this.valid,
+      createdOn: this.createdOn
+    }
+  }
+
+  /**
+   * Validates domain and send it to firestore
+   * @returns {Domain}
+   */
+  validate () {
+    console.info('Sending toJson to FirebaseDB:', this.toJson())
+    return DB.connection().collection(domainCollection)
+      .add(this.toJson())
+      .then(res => {
+        this._id = res.id
+        this._createdOn = this._createdOn.toLocaleString()
+        return this
+      })
+  }
+
+  /**
+   * Invalidates domain by id in firestore
+   * @param {string} id the id of the domain to be invalidated
+   * @returns {Domain}
+   */
+  static invalidate (id) {
+    return DB.connection().collection(domainCollection)
+      .doc(id)
+      .update({ valid: false, deletedOn: new Date() })
+  }
+
+  /**
+   * Converts from firestore format to Domain
+   * @returns {Domain}
+   */
+  static fromDocumentSnapshot (doc) {
+    const data = doc.data()
+    const id = doc.id
+    const name = data.name
+    const valid = data.valid
+    const deletedOn = data.deletedOn ? data.deletedOn.toDate().toLocaleString() : null
+    const createdOn = data.createdOn.toDate().toLocaleString()
+    return new Domain(id, name, valid, createdOn, deletedOn)
+  }
+
+  /**
+   * Check if domain already exists in valid list
+   * @returns {Promise<Boolean>}
+   */
+  static checkIfDomainExists (name) {
+    return DB.connection().collection(domainCollection)
+      .where('valid', '==', true)
+      .where('name', '==', name)
+      .get()
+      .then(res => {
+        return res.docs.length !== 0
+      })
+  }
+
+  /**
+   * Gets all the valid domains from firestore
+   * @returns {Promise<Domain[]>}
+   */
+  static listValidDomains () {
+    return DB.connection().collection(domainCollection)
+      .where('valid', '==', true)
+      .orderBy('name')
+      .get()
+      .then(res => {
+        return res.docs.map(i => Domain.fromDocumentSnapshot(i))
+      })
+  }
+
+  /**
+   * Gets all the invalidated domains from firestore
+   * @returns {Promise<Domain[]>}
+   */
+  static listInvalidDomains () {
+    return DB.connection().collection(domainCollection)
+      .where('valid', '==', false)
+      .orderBy('name')
+      .orderBy('createdOn')
+      .get()
+      .then(res => {
+        return res.docs.map(i => Domain.fromDocumentSnapshot(i))
+      })
+  }
+}
+
+export const Domain = domain

--- a/common/model/domain.test.js
+++ b/common/model/domain.test.js
@@ -1,0 +1,130 @@
+import { Domain } from './domain'
+import { FirestoreDate, FirestoreMock } from '../test_helpers/firestore.mock'
+import DB from '../db/db'
+
+const date = new FirestoreDate(new Date())
+const domain1 = { id: 'id_1', data: () => new Domain(null, 'one.com', true, date, null).toJson() }
+
+describe('The Domain model', () => {
+  const firestoreMock = new FirestoreMock()
+  let model
+  beforeEach(() => {
+    const DBSpy = jest.spyOn(DB, 'connection').mockImplementation(() => firestoreMock)
+    DBSpy.mockClear()
+    firestoreMock.reset()
+    model = new Domain(0, 'test.com', true, date, null)
+  })
+  it('should correctly instantiate the class', () => {
+    expect(model.id).toEqual(0)
+    expect(model.name).toEqual('test.com')
+    expect(model.valid).toEqual(true)
+    expect(model.createdOn).toEqual(date)
+    expect(model.deletedOn).toEqual(null)
+  })
+
+  describe('the listValidDomains method', () => {
+    it('should return all the validated domains in the DB', (done) => {
+      firestoreMock.mockGetReturn = {
+        docs: [
+          { id: 'id_1', data: () => new Domain(null, 'one.com', true, date, null).toJson() }
+        ]
+      }
+      Domain.listValidDomains()
+        .then(res => {
+          expect(DB.connection).toHaveBeenCalledTimes(1)
+          expect(firestoreMock.mockCollection).toBeCalledWith('domains')
+          expect(firestoreMock.mockWhere).toBeCalledWith('valid', '==', true)
+          expect(firestoreMock.mockOrderBy).toBeCalledWith('name')
+          expect(res[0].id).toEqual('id_1')
+          expect(res[0].name).toEqual('one.com')
+          expect(res[0].valid).toEqual(true)
+          expect(res[0].createdOn).toEqual(date.toDate().toLocaleString())
+          expect(res[0].deletedOn).toEqual(null)
+          done()
+        })
+        .catch(done)
+    })
+  })
+
+  describe('the listInvalidDomains method', () => {
+    it('should return all the invalidated domains in the DB', (done) => {
+      firestoreMock.mockGetReturn = {
+        docs: [
+          { id: 'id_2', data: () => new Domain(null, 'two.com', false, date, null).toJson() }
+        ]
+      }
+      Domain.listInvalidDomains()
+        .then(res => {
+          expect(DB.connection).toHaveBeenCalledTimes(1)
+          expect(firestoreMock.mockCollection).toBeCalledWith('domains')
+          expect(firestoreMock.mockWhere).toBeCalledWith('valid', '==', false)
+          expect(firestoreMock.mockOrderBy).toBeCalledWith('name')
+          expect(firestoreMock.mockOrderBy).toBeCalledWith('createdOn')
+          expect(res[0].id).toEqual('id_2')
+          expect(res[0].name).toEqual('two.com')
+          expect(res[0].valid).toEqual(false)
+          expect(res[0].createdOn).toEqual(date.toDate().toLocaleString())
+          expect(res[0].deletedOn).toEqual(null)
+          done()
+        })
+        .catch(done)
+    })
+  })
+
+  describe('the checkIfDomainExists method', () => {
+    it('should whether or not the domain exists in the DB', (done) => {
+      firestoreMock.mockGetReturn = {
+        docs: [
+          { id: 'id_2', data: () => new Domain(null, 'two.com', false, date, null).toJson() }
+        ]
+      }
+      Domain.checkIfDomainExists('test')
+        .then(res => {
+          expect(DB.connection).toHaveBeenCalledTimes(1)
+          expect(firestoreMock.mockCollection).toBeCalledWith('domains')
+          expect(firestoreMock.mockWhere).toBeCalledWith('valid', '==', true)
+          expect(firestoreMock.mockWhere).toBeCalledWith('name', '==', 'test')
+          expect(res).toEqual(true)
+          done()
+        })
+        .catch(done)
+    })
+  })
+
+  describe('the fromDocumentSnapshot method', () => {
+    it('should return a Domain object from the snapshot', () => {
+      const domain = Domain.fromDocumentSnapshot(domain1)
+      expect(DB.connection).toHaveBeenCalledTimes(0)
+      expect(domain.id).toEqual(domain1.id)
+      expect(domain.name).toEqual(domain1.data().name)
+      expect(domain.valid).toEqual(domain1.data().valid)
+      expect(domain.createdOn).toEqual(domain1.data().createdOn.toDate().toLocaleString())
+      expect(domain.deletedOn).toEqual(domain1.data().deletedOn)
+    })
+  })
+
+  describe('the invalidate method', () => {
+    it('should invalidate the domain in the DB', (done) => {
+      firestoreMock.mockGetReturn = {
+        docs: [
+          { id: 'id_2', data: () => new Domain(null, 'two.com', false, date, null).toJson() }
+        ]
+      }
+      Domain.listInvalidDomains()
+        .then(res => {
+          expect(DB.connection).toHaveBeenCalledTimes(1)
+          expect(firestoreMock.mockCollection).toBeCalledWith('domains')
+          expect(firestoreMock.mockWhere).toBeCalledWith('valid', '==', false)
+          expect(firestoreMock.mockOrderBy).toBeCalledWith('name')
+          expect(firestoreMock.mockOrderBy).toBeCalledWith('createdOn')
+          expect(res[0].id).toEqual('id_2')
+          expect(res[0].name).toEqual('two.com')
+          expect(res[0].valid).toEqual(false)
+          expect(res[0].createdOn).toEqual(date.toDate().toLocaleString())
+          expect(res[0].deletedOn).toEqual(null)
+          done()
+        })
+        .catch(done)
+    })
+  })
+})

--- a/common/model/domain.test.js
+++ b/common/model/domain.test.js
@@ -3,6 +3,7 @@ import { FirestoreDate, FirestoreMock } from '../test_helpers/firestore.mock'
 import DB from '../db/db'
 
 const date = new FirestoreDate(new Date())
+const enddate = new FirestoreDate(new Date())
 const domain1 = { id: 'id_1', data: () => new Domain(null, 'one.com', true, date, null).toJson() }
 
 describe('The Domain model', () => {
@@ -12,13 +13,13 @@ describe('The Domain model', () => {
     const DBSpy = jest.spyOn(DB, 'connection').mockImplementation(() => firestoreMock)
     DBSpy.mockClear()
     firestoreMock.reset()
-    model = new Domain(0, 'test.com', true, date, null)
+    model = new Domain(0, 'test.com', true, date.toDate(), null)
   })
   it('should correctly instantiate the class', () => {
     expect(model.id).toEqual(0)
     expect(model.name).toEqual('test.com')
     expect(model.valid).toEqual(true)
-    expect(model.createdOn).toEqual(date)
+    expect(model.createdOn).toEqual(date.toDate())
     expect(model.deletedOn).toEqual(null)
   })
 
@@ -50,7 +51,7 @@ describe('The Domain model', () => {
     it('should return all the invalidated domains in the DB', (done) => {
       firestoreMock.mockGetReturn = {
         docs: [
-          { id: 'id_2', data: () => new Domain(null, 'two.com', false, date, null).toJson() }
+          { id: 'id_2', data: () => new Domain(null, 'two.com', false, date, enddate).toJson() }
         ]
       }
       Domain.listInvalidDomains()
@@ -64,7 +65,7 @@ describe('The Domain model', () => {
           expect(res[0].name).toEqual('two.com')
           expect(res[0].valid).toEqual(false)
           expect(res[0].createdOn).toEqual(date.toDate().toLocaleString())
-          expect(res[0].deletedOn).toEqual(null)
+          expect(res[0].deletedOn).toEqual(enddate.toDate().toLocaleString())
           done()
         })
         .catch(done)
@@ -105,26 +106,47 @@ describe('The Domain model', () => {
 
   describe('the invalidate method', () => {
     it('should invalidate the domain in the DB', (done) => {
-      firestoreMock.mockGetReturn = {
-        docs: [
-          { id: 'id_2', data: () => new Domain(null, 'two.com', false, date, null).toJson() }
-        ]
-      }
-      Domain.listInvalidDomains()
+      Domain.invalidate(domain1.id)
         .then(res => {
           expect(DB.connection).toHaveBeenCalledTimes(1)
           expect(firestoreMock.mockCollection).toBeCalledWith('domains')
-          expect(firestoreMock.mockWhere).toBeCalledWith('valid', '==', false)
-          expect(firestoreMock.mockOrderBy).toBeCalledWith('name')
-          expect(firestoreMock.mockOrderBy).toBeCalledWith('createdOn')
-          expect(res[0].id).toEqual('id_2')
-          expect(res[0].name).toEqual('two.com')
-          expect(res[0].valid).toEqual(false)
-          expect(res[0].createdOn).toEqual(date.toDate().toLocaleString())
-          expect(res[0].deletedOn).toEqual(null)
+          expect(firestoreMock.mockUpdate).toBeCalledTimes(1)
+          expect(firestoreMock.mockDoc).toBeCalledTimes(1)
+          expect(firestoreMock.mockDoc).toBeCalledWith(domain1.id)
           done()
         })
         .catch(done)
+    })
+  })
+
+  describe('the validate method', () => {
+    it('should validate the domain in the DB', (done) => {
+      firestoreMock.mockAddReturn = { id: 'id_1' }
+
+      model.validate()
+        .then(res => {
+          expect(DB.connection).toHaveBeenCalledTimes(1)
+          expect(firestoreMock.mockCollection).toBeCalledWith('domains')
+          expect(firestoreMock.mockAdd).toBeCalledTimes(1)
+          expect(res.id).toEqual('id_1')
+          expect(res.name).toEqual('test.com')
+          expect(res.valid).toEqual(true)
+          expect(res.createdOn).toEqual(date.toDate().toLocaleString())
+          expect(res.deletedOn).toEqual(null)
+          done()
+        })
+        .catch(done)
+    })
+  })
+
+  describe('the toJson method', () => {
+    it('should convert the domain object to json', () => {
+      const json = model.toJson()
+      expect(DB.connection).toHaveBeenCalledTimes(0)
+      expect(json.name).toEqual('test.com')
+      expect(json.valid).toEqual(true)
+      expect(json.createdOn).toEqual(date.toDate())
+      expect(json.deletedOn).toEqual(null)
     })
   })
 })

--- a/common/test_helpers/firestore.mock.js
+++ b/common/test_helpers/firestore.mock.js
@@ -9,7 +9,7 @@ export class FirestoreMock {
     // methods that return promises
     this.mockAdd = jest.fn(() => Promise.resolve(this._mockAddReturn))
     this.mockGet = jest.fn(() => Promise.resolve(this._mockGetReturn))
-
+    this.mockUpdate = jest.fn(() => Promise.resolve(this._mockUpdateReturn))
     // methods that accepts callbacks
     this.mockOnSnaptshot = jest.fn((success, error) => success(this._mockOnSnaptshotSuccess))
 
@@ -17,6 +17,7 @@ export class FirestoreMock {
     this._mockAddReturn = null
     this._mockGetReturn = null
     this._mockOnSnaptshotSuccess = null
+    this._mockUpdateReturn = null
     // TODO add _mockOnSnaptshotError to return error results
   }
 
@@ -48,6 +49,10 @@ export class FirestoreMock {
     return this.mockOnSnaptshot(success, error)
   }
 
+  update () {
+    return this.mockUpdate()
+  }
+
   set mockAddReturn (val) {
     this._mockAddReturn = val
   }
@@ -65,7 +70,7 @@ export class FirestoreMock {
     this._mockAddReturn = null
     this._mockGetReturn = null
     this._mockOnSnaptshotSuccess = null
-
+    this._mockUpdateReturn = null
     // reset all the mocked functions
     this.mockCollection.mockClear()
     this.mockWhere.mockClear()

--- a/functions/index.js
+++ b/functions/index.js
@@ -217,7 +217,7 @@ exports.crowdToGithubPeriodicAudit = functions.pubsub
   })
 
 /**
- * Reacts to changes to the linked accounts for an app user
+ * Reacts to a newly linked account for an app user
  */
 exports.handleCrowdMemberLink = functions.firestore
   .document('/appUsers/{uid}/accounts/{accountId}')
@@ -230,7 +230,7 @@ exports.handleCrowdMemberLink = functions.firestore
   })
 
 /**
- * Reacts to a removal in the linked accounts for an app user
+ * Reacts to an unlink of an account for an app user
  */
 exports.handleCrowdMemberUnlink = functions.firestore
   .document('/appUsers/{uid}/accounts/{accountId}')
@@ -244,7 +244,7 @@ exports.handleCrowdMemberUnlink = functions.firestore
   })
 
 /**
- * Reacts to changes to an addition to the approved domains
+ * Reacts to an addition to the approved domains list
  */
 exports.linkAllExisitingAccountsUnderDomain = functions.firestore
   .document('/domains/{uid}')
@@ -255,7 +255,7 @@ exports.linkAllExisitingAccountsUnderDomain = functions.firestore
   })
 
 /**
- * Reacts to changes to a change in approved domains
+ * Reacts to a removal of a domain from the approved list
  */
 exports.unlinkAllExisitingAccountsUnderDomain = functions.firestore
   .document('/domains/{uid}')

--- a/functions/index.js
+++ b/functions/index.js
@@ -28,6 +28,7 @@ const gerrit = new Gerrit(
 
 const crowd = new Crowd(
   db,
+  functions.config().crowd.url,
   functions.config().crowd.app_name,
   functions.config().crowd.app_password)
 
@@ -42,6 +43,7 @@ const backup = new Backup(
 
 const crowdAudit = new CrowdToGitHub(
   crowdToGithubGroups,
+  functions.config().crowd.url,
   functions.config().crowd.app_name,
   functions.config().crowd.app_password,
   github)
@@ -212,4 +214,52 @@ exports.crowdToGithubPeriodicAudit = functions.pubsub
   .schedule('every 60 minutes')
   .onRun(() => {
     return crowdAudit.ManuallyAudit()
+  })
+
+/**
+ * Reacts to changes to the linked accounts for an app user
+ */
+exports.handleCrowdMemberLink = functions.firestore
+  .document('/appUsers/{uid}/accounts/{accountId}')
+  .onCreate((snapshot, context) => {
+    const data = snapshot.data()
+    const username = data.username
+    const email = data.email
+    const uid = context.params.uid
+    return crowd.addMemberToGroup(uid, username, email)
+  })
+
+/**
+ * Reacts to a removal in the linked accounts for an app user
+ */
+exports.handleCrowdMemberUnlink = functions.firestore
+  .document('/appUsers/{uid}/accounts/{accountId}')
+  .onDelete((snapshot, context) => {
+    const data = snapshot.data()
+    const username = data.username
+    const hostname = data.hostname
+    if (hostname === 'opennetworking.org') {
+      return crowd.removeUserFromGroup(username)
+    }
+  })
+
+/**
+ * Reacts to changes to an addition to the approved domains
+ */
+exports.linkAllExisitingAccountsUnderDomain = functions.firestore
+  .document('/domains/{uid}')
+  .onCreate((snapshot, context) => {
+    const data = snapshot.data()
+    const domain = data.name
+    return crowd.editAllUsersUnderDomain(domain, true)
+  })
+
+/**
+ * Reacts to changes to a change in approved domains
+ */
+exports.unlinkAllExisitingAccountsUnderDomain = functions.firestore
+  .document('/domains/{uid}')
+  .onUpdate((change, context) => {
+    const domain = change.after._fieldsProto.name.stringValue
+    return crowd.editAllUsersUnderDomain(domain, false)
   })

--- a/functions/lib/crowd.js
+++ b/functions/lib/crowd.js
@@ -245,6 +245,15 @@ function Crowd (db, onfHostname, appName, appPassword) {
     return ''
   }
 
+  /**
+   * This function adds a user to the crowd group if they link their ONF account.
+   * It checks to make sure the their email domain is in the list of valid domains and
+   * then it adds the user to the group.
+   * @param uid {string} Firebase UID, i.e. doc ID of appUsers collections
+   * @param username {string} username of user in crowd
+   * @param email {string} email of the user
+   * @return {Promise<void>}
+   */
   async function addMemberToGroup (uid, username, email) {
     // Check if email is being linked
     return admin.auth().getUser(uid)
@@ -282,6 +291,13 @@ function Crowd (db, onfHostname, appName, appPassword) {
       })
   }
 
+  /**
+   * This function adds or removes all users in the Crowd member group
+   * that have email domains that match the given domain argument
+   * @param domain {string} name of the domain that is being edited in the main list
+   * @param addDomain {boolean} true if domain is being added, false if it is being removed
+   * @return {Promise<void>}
+   */
   async function editAllUsersUnderDomain (domain, addDomain) {
     return db.collectionGroup('accounts')
       .where('hostname', '==', 'opennetworking.org')
@@ -321,6 +337,11 @@ function Crowd (db, onfHostname, appName, appPassword) {
     })
   }
 
+  /**
+   * Checks if the given user is present in the crowd group
+   * @param username username of the crowd user
+   * @return {boolean} whether the username was found in the crowd group
+   */
   async function userExists (username) {
     return await rp.get({
       ...rpConf,

--- a/functions/lib/crowd_to_github.js
+++ b/functions/lib/crowd_to_github.js
@@ -9,9 +9,9 @@ module.exports = CrowdToGitHub
  * @return {{getUsersWithGithubID: getUsersWithGithubID}}
  * @constructor
  */
-function CrowdToGitHub (groupMappings, crowdApp, crowdPassword, githubObj) {
+function CrowdToGitHub (groupMappings, crowdUrl, crowdApp, crowdPassword, githubObj) {
   async function AuditFromCrowdToGitHub () {
-    const crowd = new Crowd(null, crowdApp, crowdPassword)
+    const crowd = new Crowd(null, crowdUrl, crowdApp, crowdPassword)
     // Iterate all Crowd groups
     for (const [crowdGroup, value] of Object.entries(groupMappings)) {
       // Get all valid Users from Crowd serer (valid means the user has Github_id attribute)


### PR DESCRIPTION
This PR implements Crowd automatic linking with the CLAM. 

Here is how it's structured: 

A list of approved domains is maintained in a new tab of the admin tools @ **/admin/manage-domains**

Every time a user links their ONF account, a function is run to check if their email domain is in the list of approved domains. If it is, they are automatically added to the crowd group through a firebase cloud function. 

Every time a user UNlinks their ONF account, a cloud function is run to check if they are in the crowd group. If they are, they are removed from the crowd group.

If a domain is removed from the admin list, then a cloud function is run to remove all crowd users with under that domain. The inverse happens when a domain is added to the admin list.

Fixes #275
