### PR TITLE
Cla contributor table

### DIFF
--- a/client/src/js/Home.jsx
+++ b/client/src/js/Home.jsx
@@ -1,12 +1,11 @@
 import React from 'react'
 import { Firebase } from '../common/app/app'
-import Grid from '@material-ui/core/Grid'
 import * as _ from 'lodash'
-
 import AgreementsTable from './agreement/AgreementsTable'
 import CreateAgreementContainer from './agreement/CreateAgreementContainer'
-
 import { Agreement, AgreementType } from '../common/model/agreement'
+import { Card, Grid, Paper, CardContent, Typography } from '@material-ui/core'
+
 
 /**
  * User home screen for this CLA Manager application.
@@ -16,7 +15,8 @@ export default class Home extends React.Component {
     super(props)
     this.state = {
       individualCLATable: [],
-      institutionCLATable: []
+      institutionCLATable: [],
+      coveredCLA: []
     }
   }
 
@@ -29,7 +29,8 @@ export default class Home extends React.Component {
       // Clear all rows from the CLA tables.
       this.setState({
         individualCLATable: [],
-        institutionCLATable: []
+        institutionCLATable: [],
+        coveredCLA: []
       })
       return
     }
@@ -39,7 +40,14 @@ export default class Home extends React.Component {
         // FIXME handle the error
         console.warn(err)
       })
+      //Get CLA's that the user is covered by
+      Agreement.getCoveredCLAs().then(res => {
+        this.setState({coveredCLA: res})
+      })
+
   }
+
+
 
   /**
    * Unsubscribe from CLA DB updates.
@@ -83,6 +91,7 @@ export default class Home extends React.Component {
       marginBottom: '16px',
       marginTop: '50px'
     }
+
     return (
       <main>
         {this.props.user && (
@@ -90,6 +99,7 @@ export default class Home extends React.Component {
             <CreateAgreementContainer/>
           </Grid>
         )}
+
         <Grid container spacing={2}>
           <Grid item xs={12} md={6}>
             <AgreementsTable
@@ -105,7 +115,16 @@ export default class Home extends React.Component {
               data={this.state.institutionCLATable}
             />
           </Grid>
-        </Grid>
+        </Grid> 
+        <Grid container spacing={2}>
+          <Grid item xs={12} md={12}>
+            <AgreementsTable
+              header='Covered by:'
+              type={AgreementType.INDIVIDUAL}
+              data={this.state.coveredCLA}
+            />
+          </Grid>
+        </Grid> 
       </main>
     )
   }

--- a/common/model/appUser.js
+++ b/common/model/appUser.js
@@ -51,6 +51,18 @@ export class AppUser {
       }, errorCb)
   }
 
+  // Returns all of the accounts associated with the current user
+  listAccounts () {
+    return DB.connection().collection(userCollection)
+      .doc(this._uid)
+      .collection(accountsCollection)
+      .get()
+      .then(query => {
+        return query.docs.map(d => d.data())
+      })
+      .catch(console.error)
+  }
+
   static accountFromSnapshot (doc) {
     const data = doc.data()
     data.id = doc.id


### PR DESCRIPTION
This PR shows CLA's that a user is considered a contributor as.

At the bottom of the home CLA screen, there now exists a table that lists all the CLA's that the user is covered by.

A few questions:

- Right now if there are no CLA's, then the table simply does not exist all together. Is that fine?
- I am only getting the addendums for each agreement under 'AddendumType.CONTRIBUTOR'

<img width="1237" alt="Screen Shot 2021-08-23 at 11 25 20 PM" src="https://user-images.githubusercontent.com/25561168/130552924-2d3b9856-8da0-4666-b499-45ff5a31fce8.png">


Fixes #196 
