### PR TITLE
Fix reconcile crowd function

### DIFF
--- a/functions/index.js
+++ b/functions/index.js
@@ -198,10 +198,12 @@ exports.reconcileCrowd = functions.pubsub
   .schedule('every 24 hours')
   .onRun(() => {
     console.info('reconciling-crowd-accounts')
-    return db.collection('appUsers').get()
+    return db.collectionGroup('accounts')
+      .where('hostname', '==', 'opennetworking.org')
+      .get()
       .then(query => {
         console.info(`reconciling-${query.size}-crowd-accounts`)
-        return Promise.all(query.docs.map(d => crowd.updateCrowdUser(d.id)))
+        return Promise.all(query.docs.map(d => crowd.updateCrowdUser(d.ref.parent.parent.id)))
       })
   })
 


### PR DESCRIPTION
Currently the reconcile crowd function doesn't use the collection group to query the DB and as a result reconciles 0 accounts everytime.