### PR TITLE
Pin pylint to 2.10.x

### DIFF
--- a/gerrit/tox.ini
+++ b/gerrit/tox.ini
@@ -21,7 +21,7 @@ skipsdist = True
 [testenv]
 deps =
   flake8
-  pylint
+  pylint>=2.10,<2.11
   coverage
 
 commands=


### PR DESCRIPTION
It was removed in pylint 2.11:
https://pylint.pycqa.org/en/latest/whatsnew/2.11.html