### PR TITLE
Change GitHub ID to username in user-facing text

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ There are two supported types of CLAs:
 - Institutional CLAs, which allows a nontechnical manager in another
   organization to approve a CLA for multiple developers
 
-Code submitters are identified by their GitHub ID's or Email Addresses.
+Code submitters are identified by their GitHub usernames or email addresses.
 
 If a user hasn't signed a CLA and submits code, they are directed to the CLAM
 website to sign a CLA. Authentication is handled by single-use links sent out

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ There are two supported types of CLAs:
 - Institutional CLAs, which allows a nontechnical manager in another
   organization to approve a CLA for multiple developers
 
-Code submitters are identified by their GitHub usernames or email addresses.
+Code submitters are identified by their email addresses or GitHub usernames.
 
 If a user hasn't signed a CLA and submits code, they are directed to the CLAM
 website to sign a CLA. Authentication is handled by single-use links sent out

--- a/client/src/js/identity/IdentityForm.jsx
+++ b/client/src/js/identity/IdentityForm.jsx
@@ -50,7 +50,7 @@ function IdentityForm (props) {
               endIcon={<GitHubIcon/>}
               disabled={!props.githubAllowed}
             >
-              GithubId
+              GitHub
             </Button>
           </ButtonGroup>
           <TextValidator
@@ -85,12 +85,12 @@ function IdentityForm (props) {
             ? <TextValidator
               className={classes.textField}
               fullWidth
-              label='GitHub ID'
+              label='GitHub Username'
               name='githubId'
               value={value}
               onChange={e => setValue(e.target.value)}
               validators={['required']}
-              errorMessages={['Enter the GitHub ID associated to the identity']}
+              errorMessages={['Enter the GitHub username associated to the identity']}
               variant='outlined'
             /> : null
           }

--- a/client/src/js/text/Text.js
+++ b/client/src/js/text/Text.js
@@ -5,13 +5,13 @@ export const ClaRequestInstitutional =
 I would like to contribute to one of the Open Networking Foundation's (ONF) open source projects. This requires a Contributor License Agreement (CLA) to be signed between ONF and our company. Please find more information from the ONF CLA Information page:
 https://wiki.opennetworking.org/x/BgCUI
 
-If we don't have an Institutional CLA signed with ONF, could you please sign one? It is a click-through agreement and only takes a few minutes. Then, can you please add my email address and GitHub ID(s) as listed below to our CLA?
+If we don't have an Institutional CLA signed with ONF, could you please sign one? It is a click-through agreement and only takes a few minutes. Then, can you please add my email address and GitHub username(s) as listed below to our CLA?
 
 Please visit ONF CLA Manager to sign the CLA:
 https://cla.opennetworking.org
 
 My email to be added to the CLA: ___
 
-My GitHub ID(s) to be added to the CLA: ___
+My GitHub username(s) to be added to the CLA: ___
 
 Thank you for your support!`

--- a/functions/lib/crowd.js
+++ b/functions/lib/crowd.js
@@ -111,11 +111,11 @@ function Crowd (db, appName, appPassword) {
     logger.info(`updating-crowd-user-with-id: ${uid}`)
     const attributeMap = {
       // A set because a Crowd attribute can hold many values, but in reality we
-      // support binding to only one github ID.
+      // support binding to only one GitHub username.
       github_id: new Set(),
       // We assume as verified the following email addresses:
       // - The one used to sign up in the Firebase app
-      // - The public one from the Github profile
+      // - The public one from the GitHub profile
       verified_emails: new Set()
     }
     // Fetch firebase user record from the admin SDK.

--- a/functions/lib/crowd_webhook.js
+++ b/functions/lib/crowd_webhook.js
@@ -55,7 +55,7 @@ function CrowdWebhook (groupMappings, github) {
       if (event.user && event.user.groups) {
         if (event.oldGithubId === event.newGithubId) {
           logger.info(`Received USER_UPDATED_GITHUB for ${event.user.username} ` +
-                      `with same old and new Github IDs: ${event.user.githubId}. ` +
+                      `with same old and new Github usernames: ${event.user.githubId}. ` +
                       'Discarding event...')
           return
         }

--- a/functions/test/cla.test.js
+++ b/functions/test/cla.test.js
@@ -165,7 +165,7 @@ describe('Cla lib', () => {
       expect(await assertSucceeds(cla.updateWhitelist(addendumSnapshot)))
       // Verify whitelist
       whitelistDoc = (await whitelistRef.get()).data()
-      // We removed all github IDs
+      // We removed all GitHub usernames
       expect(!Array.isArray(whitelistDoc.github) || !whitelistDoc.github.length).toBe(true)
     })
 


### PR DESCRIPTION
Users might be confused about whether to provide the numeric Github ID used in the API or their textual username.

Hopefully, using the term `username` makes this more clear.